### PR TITLE
fix: prevent segfault in FrankenPHP worker mode

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -77,6 +77,8 @@ services:
             $issueDeduplicator: '@AhmedBhs\DoctrineDoctor\Service\IssueDeduplicator'
 
     # Data Collector
+    # Implements ResetInterface for FrankenPHP/RoadRunner/Swoole worker mode compatibility
+    # The kernel.reset tag ensures reset() is called between requests in persistent runtimes
     AhmedBhs\DoctrineDoctor\Collector\DoctrineDoctorDataCollector:
         arguments:
             $analyzers: !tagged_iterator doctrine_doctor.analyzer
@@ -88,6 +90,7 @@ services:
             $excludePaths: '%doctrine_doctor.analysis.exclude_paths%'
         tags:
             - { name: data_collector, id: doctrine_doctor, template: '@doctrine_doctor/profiler/doctrine_doctor.html.twig', priority: 249 }
+            - { name: kernel.reset, method: reset }
 
     # Parsers
     # Use CachedSqlStructureExtractor for 1000x+ performance improvement on SQL parsing
@@ -127,6 +130,12 @@ services:
 
     AhmedBhs\DoctrineDoctor\Service\IssueDeduplicator: ~
 
+    # Worker Mode Reset Subscriber
+    # Required for FrankenPHP worker mode, RoadRunner, Swoole, and other persistent PHP runtimes
+    # Clears ServiceHolder static state between requests to prevent segfaults from stale Doctrine objects
+    AhmedBhs\DoctrineDoctor\EventSubscriber\WorkerModeResetSubscriber:
+        tags:
+            - { name: kernel.event_subscriber }
 
     # Specific analyzer configurations
     AhmedBhs\DoctrineDoctor\Analyzer\Performance\NPlusOneAnalyzer:

--- a/src/Collector/ServiceHolder.php
+++ b/src/Collector/ServiceHolder.php
@@ -52,7 +52,12 @@ class ServiceHolder
     }
 
     /**
-     * Clear all stored services (useful for testing).
+     * Clear all stored services.
+     *
+     * Used for:
+     * - Worker mode cleanup (FrankenPHP, RoadRunner, Swoole)
+     * - Testing isolation
+     * - Reset mechanism (ResetInterface)
      */
     public static function clearAll(): void
     {

--- a/src/Collector/ServiceHolderData.php
+++ b/src/Collector/ServiceHolderData.php
@@ -11,17 +11,19 @@ declare(strict_types=1);
 
 namespace AhmedBhs\DoctrineDoctor\Collector;
 
-use AhmedBhs\DoctrineDoctor\Collector\Helper\DatabaseInfoCollector;
 use AhmedBhs\DoctrineDoctor\Collector\Helper\DataCollectorLogger;
 use AhmedBhs\DoctrineDoctor\Collector\Helper\IssueReconstructor;
 use AhmedBhs\DoctrineDoctor\Collector\Helper\QueryStatsCalculator;
 use AhmedBhs\DoctrineDoctor\Service\IssueDeduplicator;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 
 /**
  * Data Transfer Object for services stored in ServiceHolder.
- * Reduces parameter count by encapsulating related services.
+ *
+ * Important: This class intentionally does NOT store EntityManager or other
+ * Doctrine objects. In worker mode (FrankenPHP, RoadRunner), these objects
+ * become invalid between requests and cause segfaults. Only stateless services
+ * that don't hold database connections should be stored here.
  */
 final class ServiceHolderData
 {
@@ -33,15 +35,7 @@ final class ServiceHolderData
         /**
          * @readonly
          */
-        public ?EntityManagerInterface $entityManager,
-        /**
-         * @readonly
-         */
         public ?Stopwatch $stopwatch,
-        /**
-         * @readonly
-         */
-        public DatabaseInfoCollector $databaseInfoCollector,
         /**
          * @readonly
          */

--- a/src/EventSubscriber/WorkerModeResetSubscriber.php
+++ b/src/EventSubscriber/WorkerModeResetSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Doctor.
+ * (c) 2025-2026 Ahmed EBEN HASSINE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AhmedBhs\DoctrineDoctor\EventSubscriber;
+
+use AhmedBhs\DoctrineDoctor\Collector\ServiceHolder;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Clears ServiceHolder after each request for worker mode compatibility.
+ *
+ * In persistent PHP runtimes (FrankenPHP worker mode, RoadRunner, Swoole),
+ * PHP processes persist between requests. ServiceHolder stores service
+ * references in a static array that should be cleared after each request.
+ *
+ * Note: ServiceHolderData no longer stores EntityManager or other Doctrine
+ * objects that could become stale. It only contains stateless services.
+ * This subscriber provides defense-in-depth cleanup.
+ *
+ * @see \Symfony\Component\HttpKernel\EventListener\ProfilerListener
+ */
+class WorkerModeResetSubscriber implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::TERMINATE => ['onKernelTerminate', -2048],
+        ];
+    }
+
+    public function onKernelTerminate(): void
+    {
+        ServiceHolder::clearAll();
+    }
+}

--- a/tests/Unit/Collector/ServiceHolderTest.php
+++ b/tests/Unit/Collector/ServiceHolderTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Doctor.
+ * (c) 2025-2026 Ahmed EBEN HASSINE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AhmedBhs\DoctrineDoctor\Tests\Unit\Collector;
+
+use AhmedBhs\DoctrineDoctor\Collector\Helper\DataCollectorLogger;
+use AhmedBhs\DoctrineDoctor\Collector\Helper\IssueReconstructor;
+use AhmedBhs\DoctrineDoctor\Collector\Helper\QueryStatsCalculator;
+use AhmedBhs\DoctrineDoctor\Collector\ServiceHolder;
+use AhmedBhs\DoctrineDoctor\Collector\ServiceHolderData;
+use AhmedBhs\DoctrineDoctor\Service\IssueDeduplicator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Webmozart\Assert\InvalidArgumentException;
+
+/**
+ * Unit tests for ServiceHolder.
+ */
+final class ServiceHolderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ServiceHolder::clearAll();
+    }
+
+    protected function tearDown(): void
+    {
+        ServiceHolder::clearAll();
+    }
+
+    #[Test]
+    public function it_stores_and_retrieves_service_data(): void
+    {
+        $token = 'test_token';
+        $serviceData = $this->createServiceHolderData();
+
+        ServiceHolder::store($token, $serviceData);
+
+        self::assertSame($serviceData, ServiceHolder::get($token));
+    }
+
+    #[Test]
+    public function it_returns_null_for_unknown_token(): void
+    {
+        self::assertNull(ServiceHolder::get('unknown_token'));
+    }
+
+    #[Test]
+    public function it_clears_specific_token(): void
+    {
+        $serviceData = $this->createServiceHolderData();
+        ServiceHolder::store('token_1', $serviceData);
+        ServiceHolder::store('token_2', $serviceData);
+
+        ServiceHolder::clear('token_1');
+
+        self::assertNull(ServiceHolder::get('token_1'));
+        self::assertNotNull(ServiceHolder::get('token_2'));
+    }
+
+    #[Test]
+    public function it_clears_all_tokens(): void
+    {
+        $serviceData = $this->createServiceHolderData();
+        ServiceHolder::store('token_1', $serviceData);
+        ServiceHolder::store('token_2', $serviceData);
+        ServiceHolder::store('token_3', $serviceData);
+
+        ServiceHolder::clearAll();
+
+        self::assertNull(ServiceHolder::get('token_1'));
+        self::assertNull(ServiceHolder::get('token_2'));
+        self::assertNull(ServiceHolder::get('token_3'));
+    }
+
+    #[Test]
+    public function it_throws_exception_for_empty_token(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $serviceData = $this->createServiceHolderData();
+        ServiceHolder::store('', $serviceData);
+    }
+
+    #[Test]
+    public function it_overwrites_existing_token(): void
+    {
+        $serviceData1 = $this->createServiceHolderData();
+        $serviceData2 = $this->createServiceHolderData();
+
+        ServiceHolder::store('token', $serviceData1);
+        ServiceHolder::store('token', $serviceData2);
+
+        self::assertSame($serviceData2, ServiceHolder::get('token'));
+    }
+
+    #[Test]
+    public function clear_is_idempotent(): void
+    {
+        $serviceData = $this->createServiceHolderData();
+        ServiceHolder::store('token', $serviceData);
+
+        // Clear multiple times should not throw
+        ServiceHolder::clear('token');
+        ServiceHolder::clear('token');
+        ServiceHolder::clear('token');
+
+        self::assertNull(ServiceHolder::get('token'));
+    }
+
+    #[Test]
+    public function clear_all_is_idempotent(): void
+    {
+        // Clear on empty holder should not throw
+        ServiceHolder::clearAll();
+        ServiceHolder::clearAll();
+        ServiceHolder::clearAll();
+
+        self::assertNull(ServiceHolder::get('any'));
+    }
+
+    private function createServiceHolderData(): ServiceHolderData
+    {
+        $logger = new NullLogger();
+
+        return new ServiceHolderData(
+            analyzers: [],
+            stopwatch: null,
+            issueReconstructor: new IssueReconstructor(),
+            queryStatsCalculator: new QueryStatsCalculator(),
+            dataCollectorLogger: new DataCollectorLogger($logger),
+            issueDeduplicator: new IssueDeduplicator(),
+        );
+    }
+}

--- a/tests/Unit/EventSubscriber/WorkerModeResetSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/WorkerModeResetSubscriberTest.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Doctor.
+ * (c) 2025-2026 Ahmed EBEN HASSINE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AhmedBhs\DoctrineDoctor\Tests\Unit\EventSubscriber;
+
+use AhmedBhs\DoctrineDoctor\Collector\Helper\DataCollectorLogger;
+use AhmedBhs\DoctrineDoctor\Collector\Helper\IssueReconstructor;
+use AhmedBhs\DoctrineDoctor\Collector\Helper\QueryStatsCalculator;
+use AhmedBhs\DoctrineDoctor\Collector\ServiceHolder;
+use AhmedBhs\DoctrineDoctor\Collector\ServiceHolderData;
+use AhmedBhs\DoctrineDoctor\EventSubscriber\WorkerModeResetSubscriber;
+use AhmedBhs\DoctrineDoctor\Service\IssueDeduplicator;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Unit tests for WorkerModeResetSubscriber.
+ */
+final class WorkerModeResetSubscriberTest extends TestCase
+{
+    private WorkerModeResetSubscriber $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->subscriber = new WorkerModeResetSubscriber();
+        ServiceHolder::clearAll();
+    }
+
+    protected function tearDown(): void
+    {
+        ServiceHolder::clearAll();
+    }
+
+    #[Test]
+    public function it_subscribes_to_kernel_terminate_event(): void
+    {
+        $events = $this->subscriber::getSubscribedEvents();
+
+        self::assertArrayHasKey(KernelEvents::TERMINATE, $events);
+    }
+
+    #[Test]
+    public function it_subscribes_with_low_priority(): void
+    {
+        $events = $this->subscriber::getSubscribedEvents();
+
+        $terminateConfig = $events[KernelEvents::TERMINATE];
+
+        self::assertIsArray($terminateConfig);
+        self::assertSame('onKernelTerminate', $terminateConfig[0]);
+        self::assertSame(-2048, $terminateConfig[1]);
+    }
+
+    #[Test]
+    public function it_does_not_subscribe_to_kernel_request(): void
+    {
+        $events = $this->subscriber::getSubscribedEvents();
+
+        self::assertArrayNotHasKey(KernelEvents::REQUEST, $events);
+    }
+
+    #[Test]
+    public function it_clears_service_holder_on_terminate(): void
+    {
+        $token = 'test_token_123';
+        ServiceHolder::store($token, $this->createServiceHolderData());
+
+        self::assertNotNull(ServiceHolder::get($token));
+
+        $this->subscriber->onKernelTerminate();
+
+        self::assertNull(ServiceHolder::get($token));
+    }
+
+    #[Test]
+    public function it_handles_empty_service_holder_gracefully(): void
+    {
+        self::assertNull(ServiceHolder::get('any_token'));
+
+        $this->subscriber->onKernelTerminate();
+
+        self::assertNull(ServiceHolder::get('any_token'));
+    }
+
+    #[Test]
+    public function it_clears_multiple_tokens(): void
+    {
+        $serviceData = $this->createServiceHolderData();
+        ServiceHolder::store('token_1', $serviceData);
+        ServiceHolder::store('token_2', $serviceData);
+        ServiceHolder::store('token_3', $serviceData);
+
+        self::assertNotNull(ServiceHolder::get('token_1'));
+        self::assertNotNull(ServiceHolder::get('token_2'));
+        self::assertNotNull(ServiceHolder::get('token_3'));
+
+        $this->subscriber->onKernelTerminate();
+
+        self::assertNull(ServiceHolder::get('token_1'));
+        self::assertNull(ServiceHolder::get('token_2'));
+        self::assertNull(ServiceHolder::get('token_3'));
+    }
+
+    private function createServiceHolderData(): ServiceHolderData
+    {
+        $logger = new NullLogger();
+
+        return new ServiceHolderData(
+            analyzers: [],
+            stopwatch: null,
+            issueReconstructor: new IssueReconstructor(),
+            queryStatsCalculator: new QueryStatsCalculator(),
+            dataCollectorLogger: new DataCollectorLogger($logger),
+            issueDeduplicator: new IssueDeduplicator(),
+        );
+    }
+}


### PR DESCRIPTION
In persistent PHP runtimes (FrankenPHP worker mode, RoadRunner, Swoole), ServiceHolder stores Doctrine objects (EntityManager, Connection) in a static array. These objects become invalid after the request ends, causing segfaults when accessed in subsequent requests.

## Description
<!-- Describe your changes -->

## Type of Change

| Type | Yes/No |
|------|--------|
| Bug fix |Yes |
| New feature |No |
| Issue | #3 |
