### PR TITLE
refactor(issue): extract deduplication contract from IssueInterface

### DIFF
--- a/src/Collector/Helper/IssueReconstructor.php
+++ b/src/Collector/Helper/IssueReconstructor.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace AhmedBhs\DoctrineDoctor\Collector\Helper;
 
+use AhmedBhs\DoctrineDoctor\Issue\DeduplicatableIssueInterface;
 use AhmedBhs\DoctrineDoctor\Issue\IssueInterface;
 use AhmedBhs\DoctrineDoctor\Suggestion\CodeSuggestion;
 use AhmedBhs\DoctrineDoctor\Suggestion\ModernSuggestion;
@@ -56,7 +57,7 @@ final readonly class IssueReconstructor
         $issue = new $issueClass(array_merge($issueData, ['suggestion' => $suggestion]));
 
         // Reconstruct and attach duplicated issues if any
-        if (count($duplicatedIssuesData) > 0) {
+        if (count($duplicatedIssuesData) > 0 && $issue instanceof DeduplicatableIssueInterface) {
             $duplicatedIssues = array_map(
                 $this->reconstructSimplifiedIssue(...),
                 $duplicatedIssuesData,

--- a/src/Issue/AbstractIssue.php
+++ b/src/Issue/AbstractIssue.php
@@ -16,7 +16,7 @@ use AhmedBhs\DoctrineDoctor\ValueObject\IssueType;
 use AhmedBhs\DoctrineDoctor\ValueObject\Severity;
 use Webmozart\Assert\Assert;
 
-abstract class AbstractIssue implements IssueInterface
+abstract class AbstractIssue implements DeduplicatableIssueInterface
 {
     protected string $type;
 

--- a/src/Issue/DeduplicatableIssueInterface.php
+++ b/src/Issue/DeduplicatableIssueInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Doctor.
+ * (c) 2025-2026 Ahmed EBEN HASSINE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AhmedBhs\DoctrineDoctor\Issue;
+
+/**
+ * Dedicated contract for issues that can hold deduplicated sibling issues.
+ * Keeps deduplication concern out of the base IssueInterface.
+ */
+interface DeduplicatableIssueInterface extends IssueInterface
+{
+    /**
+     * Get issues that were deduplicated and hidden because they resemble this one.
+     * @return IssueInterface[]
+     */
+    public function getDuplicatedIssues(): array;
+
+    /**
+     * Add an issue that was deduplicated and hidden.
+     */
+    public function addDuplicatedIssue(IssueInterface $issue): void;
+
+    /**
+     * Set all duplicated issues at once.
+     * @param IssueInterface[] $issues
+     */
+    public function setDuplicatedIssues(array $issues): void;
+}

--- a/src/Issue/IssueInterface.php
+++ b/src/Issue/IssueInterface.php
@@ -43,21 +43,4 @@ interface IssueInterface
     public function getData(): array;
 
     public function toArray(): array;
-
-    /**
-     * Get issues that were deduplicated and hidden because they resemble this one.
-     * @return IssueInterface[]
-     */
-    public function getDuplicatedIssues(): array;
-
-    /**
-     * Add an issue that was deduplicated and hidden.
-     */
-    public function addDuplicatedIssue(IssueInterface $issue): void;
-
-    /**
-     * Set all duplicated issues at once.
-     * @param IssueInterface[] $issues
-     */
-    public function setDuplicatedIssues(array $issues): void;
 }

--- a/src/Service/IssueDeduplicator.php
+++ b/src/Service/IssueDeduplicator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace AhmedBhs\DoctrineDoctor\Service;
 
 use AhmedBhs\DoctrineDoctor\Collection\IssueCollection;
+use AhmedBhs\DoctrineDoctor\Issue\DeduplicatableIssueInterface;
 use AhmedBhs\DoctrineDoctor\Issue\IssueInterface;
 use AhmedBhs\DoctrineDoctor\ValueObject\Severity;
 use Webmozart\Assert\Assert;
@@ -351,7 +352,7 @@ final class IssueDeduplicator
         }
 
         // Attach duplicates to the best issue
-        if (null !== $bestIssue && count($duplicates) > 0) {
+        if (null !== $bestIssue && count($duplicates) > 0 && $bestIssue instanceof DeduplicatableIssueInterface) {
             $bestIssue->setDuplicatedIssues($duplicates);
         }
 

--- a/tests/Unit/Service/IssueDeduplicatorTest.php
+++ b/tests/Unit/Service/IssueDeduplicatorTest.php
@@ -13,6 +13,7 @@ namespace AhmedBhs\DoctrineDoctor\Tests\Unit\Service;
 
 use AhmedBhs\DoctrineDoctor\Collection\IssueCollection;
 use AhmedBhs\DoctrineDoctor\DTO\QueryData;
+use AhmedBhs\DoctrineDoctor\Issue\DeduplicatableIssueInterface;
 use AhmedBhs\DoctrineDoctor\Issue\IssueInterface;
 use AhmedBhs\DoctrineDoctor\Service\IssueDeduplicator;
 use AhmedBhs\DoctrineDoctor\Suggestion\SuggestionInterface;
@@ -355,6 +356,7 @@ final class IssueDeduplicatorTest extends TestCase
         self::assertCount(1, $deduplicated, 'Should keep only the N+1 issue');
         $bestIssue = $deduplicated->toArray()[0];
         self::assertSame('N+1 Query detected: 212 queries on BillLine', $bestIssue->getTitle());
+        self::assertInstanceOf(DeduplicatableIssueInterface::class, $bestIssue);
 
         // Verify duplicated issues are tracked
         $duplicates = $bestIssue->getDuplicatedIssues();
@@ -376,7 +378,7 @@ final class IssueDeduplicatorTest extends TestCase
         Severity $severity,
         array $queries,
     ): IssueInterface {
-        return new class($title, $description, $severity, $queries) implements IssueInterface {
+        return new class($title, $description, $severity, $queries) implements DeduplicatableIssueInterface {
             private array $duplicatedIssues = [];
 
             public function __construct(


### PR DESCRIPTION
 Extract deduplication concerns out of IssueInterface by introducing DeduplicatableIssueInterface.

  This PR:

  - Removes dedup-specific methods from IssueInterface (getDuplicatedIssues, addDuplicatedIssue, setDuplicatedIssues).
  - Adds DeduplicatableIssueInterface for issues that need duplicate-tracking state.
  - Updates AbstractIssue to implement the new dedicated interface.
  - Updates IssueDeduplicator and IssueReconstructor to use the dedicated interface safely.

  Result: cleaner core issue contract, better separation of concerns, and less interface pollution while preserving existing deduplication behavior.


Closes #42