### PR TITLE
feat: add security analyzers and repeated lookup detection

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -336,6 +336,20 @@ services:
         tags:
             - { name: doctrine_doctor.analyzer }
 
+    AhmedBhs\DoctrineDoctor\Analyzer\Security\OverprivilegedDatabaseUserAnalyzer:
+        arguments:
+            $connection: '@doctrine.dbal.default_connection'
+            $suggestionFactory: '@AhmedBhs\DoctrineDoctor\Factory\SuggestionFactory'
+        tags:
+            - { name: doctrine_doctor.analyzer }
+
+    AhmedBhs\DoctrineDoctor\Analyzer\Security\HardcodedDatabaseCredentialsAnalyzer:
+        arguments:
+            $connection: '@doctrine.dbal.default_connection'
+            $suggestionFactory: '@AhmedBhs\DoctrineDoctor\Factory\SuggestionFactory'
+        tags:
+            - { name: doctrine_doctor.analyzer }
+
     AhmedBhs\DoctrineDoctor\Analyzer\Integrity\ForeignKeyMappingAnalyzer:
         arguments:
             $suggestionFactory: '@AhmedBhs\DoctrineDoctor\Factory\SuggestionFactory'
@@ -492,6 +506,7 @@ services:
     AhmedBhs\DoctrineDoctor\Analyzer\Integrity\PropertyTypeMismatchAnalyzer:
         arguments:
             $entityManager: '@doctrine_doctor.entity_manager'
+            $suggestionFactory: '@AhmedBhs\DoctrineDoctor\Factory\SuggestionFactory'
         tags:
             - { name: doctrine_doctor.analyzer }
 

--- a/src/Analyzer/Integrity/CollectionInitializationAnalyzer.php
+++ b/src/Analyzer/Integrity/CollectionInitializationAnalyzer.php
@@ -183,9 +183,10 @@ class CollectionInitializationAnalyzer implements \AhmedBhs\DoctrineDoctor\Analy
 
     private function createMissingConstructorIssue(string $entityClass, string $fieldName, array|object $mapping): IntegrityIssue
     {
-        $shortClassName = $this->shortClassName($entityClass);
-        $targetEntity   = $this->shortClassName(MappingHelper::getString($mapping, 'targetEntity') ?? 'Unknown');
+        $shortClassName  = $this->shortClassName($entityClass);
+        $targetEntity    = $this->shortClassName(MappingHelper::getString($mapping, 'targetEntity') ?? 'Unknown');
         $associationType = $this->getAssociationType($mapping);
+        $mappedBy        = MappingHelper::getString($mapping, 'mappedBy');
 
         /** @var IntegrityIssue $issue */
         $issue = $this->issueFactory->createFromArray(['type' => IssueType::INTEGRITY_GENERIC->value,
@@ -206,6 +207,7 @@ class CollectionInitializationAnalyzer implements \AhmedBhs\DoctrineDoctor\Analy
                     'field_name' => $fieldName,
                     'target_entity' => $targetEntity,
                     'association_type' => $associationType,
+                    'mapped_by' => $mappedBy,
                     'has_constructor' => false,
                     'backtrace' => null,
                 ],
@@ -230,9 +232,10 @@ class CollectionInitializationAnalyzer implements \AhmedBhs\DoctrineDoctor\Analy
         array|object $mapping,
         \ReflectionMethod $reflectionMethod,
     ): IntegrityIssue {
-        $shortClassName = $this->shortClassName($entityClass);
-        $targetEntity   = $this->shortClassName(MappingHelper::getString($mapping, 'targetEntity') ?? 'Unknown');
+        $shortClassName  = $this->shortClassName($entityClass);
+        $targetEntity    = $this->shortClassName(MappingHelper::getString($mapping, 'targetEntity') ?? 'Unknown');
         $associationType = $this->getAssociationType($mapping);
+        $mappedBy        = MappingHelper::getString($mapping, 'mappedBy');
 
         /** @var IntegrityIssue $issue */
         $issue = $this->issueFactory->createFromArray(['type' => IssueType::INTEGRITY_GENERIC->value,
@@ -253,6 +256,7 @@ class CollectionInitializationAnalyzer implements \AhmedBhs\DoctrineDoctor\Analy
                     'field_name' => $fieldName,
                     'target_entity' => $targetEntity,
                     'association_type' => $associationType,
+                    'mapped_by' => $mappedBy,
                     'has_constructor' => true,
                     'backtrace' => sprintf('%s:%d', $reflectionMethod->getFileName() ?: 'unknown', $reflectionMethod->getStartLine() ?: 0),
                 ],

--- a/src/Analyzer/Integrity/PropertyTypeMismatchAnalyzer.php
+++ b/src/Analyzer/Integrity/PropertyTypeMismatchAnalyzer.php
@@ -16,10 +16,13 @@ use AhmedBhs\DoctrineDoctor\Collection\IssueCollection;
 use AhmedBhs\DoctrineDoctor\Collection\QueryDataCollection;
 use AhmedBhs\DoctrineDoctor\DTO\IssueData;
 use AhmedBhs\DoctrineDoctor\Factory\IssueFactoryInterface;
+use AhmedBhs\DoctrineDoctor\Factory\SuggestionFactoryInterface;
 use AhmedBhs\DoctrineDoctor\Helper\MappingHelper;
 use AhmedBhs\DoctrineDoctor\Issue\IssueInterface;
 use AhmedBhs\DoctrineDoctor\ValueObject\IssueType;
 use AhmedBhs\DoctrineDoctor\ValueObject\Severity;
+use AhmedBhs\DoctrineDoctor\ValueObject\SuggestionMetadata;
+use AhmedBhs\DoctrineDoctor\ValueObject\SuggestionType;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping\ClassMetadata;
 use ReflectionEnum;
@@ -44,6 +47,7 @@ class PropertyTypeMismatchAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer\
     public function __construct(
         private readonly EntityManagerInterface $entityManager,
         private readonly IssueFactoryInterface $issueFactory,
+        private readonly ?SuggestionFactoryInterface $suggestionFactory = null,
     ) {
     }
 
@@ -342,15 +346,95 @@ class PropertyTypeMismatchAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer\
         $description .= "Impact: Doctrine may detect false changes and issue unnecessary UPDATE queries.\n";
         $description .= "Impact: Persisted values can diverge from PHP expectations at runtime.";
 
+        $suggestion = $this->buildSuggestion($shortClassName, $fieldName, $expectedType, $actualType, $severity);
+
         $issueData = new IssueData(
             type: IssueType::PROPERTY_TYPE_MISMATCH->value,
             title: sprintf('Type Mismatch: %s::\$%s', $shortClassName, $fieldName),
             description: $description,
             severity: $severity,
-            suggestion: null,
+            suggestion: $suggestion,
             queries: [],
         );
 
         return $this->issueFactory->create($issueData);
+    }
+
+    private function buildSuggestion(
+        string $shortClassName,
+        string $fieldName,
+        string $expectedType,
+        string $actualType,
+        Severity $severity,
+    ): ?\AhmedBhs\DoctrineDoctor\Suggestion\SuggestionInterface {
+        if (null === $this->suggestionFactory) {
+            return null;
+        }
+
+        $isNullabilityMismatch = str_contains($expectedType, 'nullable');
+
+        if ($isNullabilityMismatch && str_contains($expectedType, 'non-nullable') && str_contains($actualType, 'nullable')) {
+            $baseType = preg_replace('/^\?/', '', preg_replace('/\s*\(nullable\)/', '', $actualType));
+            $badCode = sprintf("#[ORM\\Column(type: '...')]  // nullable not set (defaults to false)\nprivate ?%s \$%s = null;", $baseType, $fieldName);
+            $goodCode = sprintf(
+                "// Option 1: Make the column nullable\n#[ORM\\Column(type: '...', nullable: true)]\nprivate ?%s \$%s = null;\n\n// Option 2: Make the PHP property non-nullable\n#[ORM\\Column(type: '...')]\nprivate %s \$%s;",
+                $baseType,
+                $fieldName,
+                $baseType,
+                $fieldName,
+            );
+            $descriptionText = sprintf(
+                'Property %s::$%s is declared as nullable in PHP (?%s) but the Doctrine column is non-nullable. Either add nullable: true to the mapping or remove the ? from the type hint.',
+                $shortClassName,
+                $fieldName,
+                $baseType,
+            );
+        } elseif ($isNullabilityMismatch && str_contains($expectedType, 'nullable') && str_contains($actualType, 'non-nullable')) {
+            $baseType = preg_replace('/\s*\(non-nullable\)/', '', $actualType);
+            $badCode = sprintf("#[ORM\\Column(type: '...', nullable: true)]\nprivate %s \$%s;", $baseType, $fieldName);
+            $goodCode = sprintf(
+                "// Option 1: Make the PHP property nullable\n#[ORM\\Column(type: '...', nullable: true)]\nprivate ?%s \$%s = null;\n\n// Option 2: Remove nullable from the column\n#[ORM\\Column(type: '...')]\nprivate %s \$%s;",
+                $baseType,
+                $fieldName,
+                $baseType,
+                $fieldName,
+            );
+            $descriptionText = sprintf(
+                'Property %s::$%s is declared as non-nullable in PHP (%s) but the Doctrine column is nullable. Either add ? to the type hint or remove nullable: true from the mapping.',
+                $shortClassName,
+                $fieldName,
+                $baseType,
+            );
+        } else {
+            $badCode = sprintf("private %s \$%s;  // Doctrine expects: %s", $actualType, $fieldName, $expectedType);
+            $goodCode = sprintf("private %s \$%s;", preg_replace('/\s*\(.*\)/', '', $expectedType), $fieldName);
+            $descriptionText = sprintf(
+                'Property %s::$%s has type %s but Doctrine expects %s.',
+                $shortClassName,
+                $fieldName,
+                $actualType,
+                $expectedType,
+            );
+        }
+
+        return $this->suggestionFactory->createFromTemplate(
+            templateName: 'Integrity/type_hint_mismatch',
+            context: [
+                'bad_code' => $badCode,
+                'good_code' => $goodCode,
+                'description' => $descriptionText,
+                'performance_impact' => [
+                    'Unnecessary UPDATE queries executed on every flush',
+                    'Increased database load from phantom changes',
+                    'Potential runtime errors from null/non-null mismatch',
+                ],
+            ],
+            suggestionMetadata: new SuggestionMetadata(
+                type: SuggestionType::integrity(),
+                severity: $severity,
+                title: sprintf('Fix type mismatch on %s::$%s', $shortClassName, $fieldName),
+                tags: ['integrity', 'doctrine', 'type-mismatch', 'property'],
+            ),
+        );
     }
 }

--- a/src/Analyzer/Parser/CachedSqlStructureExtractor.php
+++ b/src/Analyzer/Parser/CachedSqlStructureExtractor.php
@@ -111,6 +111,11 @@ class CachedSqlStructureExtractor extends SqlStructureExtractor
     private static array $hasComplexWhereConditionsCache = [];
 
     /**
+     * @var array<string, array{table: string, column: string}|null> Cache for repeated lookup pattern detection
+     */
+    private static array $repeatedLookupCache = [];
+
+    /**
      * @var int Cache hit counter
      */
     private static int $hits = 0;
@@ -488,7 +493,8 @@ class CachedSqlStructureExtractor extends SqlStructureExtractor
             + count(self::$hasGroupByCache)
             + count(self::$groupByColumnsCache)
             + count(self::$hasLeadingWildcardLikeCache)
-            + count(self::$hasDistinctCache);
+            + count(self::$hasDistinctCache)
+            + count(self::$repeatedLookupCache);
 
         return [
             'hits' => self::$hits,
@@ -496,6 +502,26 @@ class CachedSqlStructureExtractor extends SqlStructureExtractor
             'hitRate' => $total > 0 ? round((self::$hits / $total) * 100, 2) : 0.0,
             'entries' => $entries,
         ];
+    }
+
+    /**
+     * @return array{table: string, column: string}|null
+     */
+    #[\Override]
+    public function detectRepeatedLookupPattern(string $sql): ?array
+    {
+        $key = md5($sql);
+
+        if (array_key_exists($key, self::$repeatedLookupCache)) {
+            ++self::$hits;
+
+            return self::$repeatedLookupCache[$key];
+        }
+
+        ++self::$misses;
+        self::$repeatedLookupCache[$key] = parent::detectRepeatedLookupPattern($sql);
+
+        return self::$repeatedLookupCache[$key];
     }
 
     /**
@@ -518,6 +544,7 @@ class CachedSqlStructureExtractor extends SqlStructureExtractor
         self::$groupByColumnsCache = [];
         self::$hasLeadingWildcardLikeCache = [];
         self::$hasDistinctCache = [];
+        self::$repeatedLookupCache = [];
         self::$hits = 0;
         self::$misses = 0;
     }

--- a/src/Analyzer/Parser/Interface/PatternDetectorInterface.php
+++ b/src/Analyzer/Parser/Interface/PatternDetectorInterface.php
@@ -71,6 +71,15 @@ interface PatternDetectorInterface
     public function detectInsertQuery(string $sql): ?string;
 
     /**
+     * Detects repeated lookup pattern: SELECT ... FROM table WHERE column = ?
+     * where column is not an ID or foreign key (e.g., slug, email, code).
+     * This pattern suggests repeated findOneBy/findBy calls in a loop.
+     *
+     * @return array{table: string, column: string}|null
+     */
+    public function detectRepeatedLookupPattern(string $sql): ?array;
+
+    /**
      * Checks if a SQL query is a SELECT statement.
      */
     public function isSelectQuery(string $sql): bool;

--- a/src/Analyzer/Parser/SqlPatternDetector.php
+++ b/src/Analyzer/Parser/SqlPatternDetector.php
@@ -208,6 +208,54 @@ final readonly class SqlPatternDetector implements PatternDetectorInterface
         return $statement->into->dest->table ?? null;
     }
 
+    public function detectRepeatedLookupPattern(string $sql): ?array
+    {
+        $parser = new Parser($sql);
+        $statement = $parser->statements[0] ?? null;
+
+        if (!$statement instanceof SelectStatement) {
+            return null;
+        }
+
+        $mainTable = $this->joinExtractor->extractMainTable($sql);
+        if (null === $mainTable || null === $mainTable['table']) {
+            return null;
+        }
+
+        if (null === $statement->where || [] === $statement->where) {
+            return null;
+        }
+
+        if (null !== $statement->join && [] !== $statement->join) {
+            return null;
+        }
+
+        $conditions = [];
+        foreach ($statement->where as $condition) {
+            if (!$condition instanceof Condition) {
+                continue;
+            }
+
+            $expr = trim((string) $condition->expr);
+
+            if (1 === preg_match('/(?:\w+\.)?(\w+)\s*=\s*(?:\?|\d+|\'[^\']*\'|"[^"]*")/i', $expr, $matches)) {
+                $column = strtolower($matches[1]);
+                if ('id' !== $column && !str_ends_with($column, '_id')) {
+                    $conditions[] = $column;
+                }
+            }
+        }
+
+        if (1 === count($conditions)) {
+            return [
+                'table' => $mainTable['table'],
+                'column' => $conditions[0],
+            ];
+        }
+
+        return null;
+    }
+
     public function isSelectQuery(string $sql): bool
     {
         $parser = new Parser($sql);

--- a/src/Analyzer/Parser/SqlStructureExtractor.php
+++ b/src/Analyzer/Parser/SqlStructureExtractor.php
@@ -189,6 +189,14 @@ class SqlStructureExtractor
         return $this->patternDetector->detectPartialCollectionLoad($sql);
     }
 
+    /**
+     * @return array{table: string, column: string}|null
+     */
+    public function detectRepeatedLookupPattern(string $sql): ?array
+    {
+        return $this->patternDetector->detectRepeatedLookupPattern($sql);
+    }
+
     // ==================== CONDITION ANALYZER DELEGATION ====================
 
     /**

--- a/src/Analyzer/Performance/NPlusOneAnalyzer.php
+++ b/src/Analyzer/Performance/NPlusOneAnalyzer.php
@@ -203,7 +203,7 @@ class NPlusOneAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer\AnalyzerInte
      *
      * OPTIMIZED: Uses CachedSqlStructureExtractor (transparent via DI) for 1000x+ speedup
      *
-     * @return array{type: 'proxy'|'collection'|'unknown', hasLimit: bool}
+     * @return array{type: 'proxy'|'collection'|'lookup'|'unknown', hasLimit: bool}
      */
     private function detectNPlusOneType(string $sql): array
     {
@@ -220,6 +220,11 @@ class NPlusOneAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer\AnalyzerInte
         // Collection pattern: WHERE foreign_key_id = ? (loads collection)
         if (null !== $this->sqlExtractor->detectNPlusOnePattern($sql)) {
             return ['type' => 'collection', 'hasLimit' => false];
+        }
+
+        // Repeated lookup pattern: WHERE column = ? (e.g., slug, email, code)
+        if (null !== $this->sqlExtractor->detectRepeatedLookupPattern($sql)) {
+            return ['type' => 'lookup', 'hasLimit' => false];
         }
 
         return ['type' => 'unknown', 'hasLimit' => false];
@@ -278,6 +283,32 @@ class NPlusOneAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer\AnalyzerInte
                         severity: $severity,
                         title: sprintf('Proxy N+1 Query: %d queries for %s.%s', $queryCount, $entity, 'relation'),
                         tags: ['performance', 'doctrine', 'batch-fetch', 'n+1', 'proxy'],
+                    ),
+                );
+            }
+        }
+
+        // Repeated lookup: WHERE column = ? (e.g., slug, email, code)
+        if ('lookup' === $type['type']) {
+            $lookupPattern = $this->sqlExtractor->detectRepeatedLookupPattern($sql);
+            if (null !== $lookupPattern) {
+                $entity = $this->tableToEntity($lookupPattern['table']);
+                $column = $lookupPattern['column'];
+                $severity = $this->calculateEagerLoadingSeverity($queryCount);
+
+                return $this->suggestionFactory->createFromTemplate(
+                    templateName: 'Performance/repeated_lookup',
+                    context: [
+                        'entity' => $entity,
+                        'column' => $column,
+                        'query_count' => $queryCount,
+                        'trigger_location' => $triggerLocation,
+                    ],
+                    suggestionMetadata: new SuggestionMetadata(
+                        type: SuggestionType::performance(),
+                        severity: $severity,
+                        title: sprintf('Repeated Lookup: %d queries for %s by %s', $queryCount, $entity, $column),
+                        tags: ['performance', 'doctrine', 'repeated-lookup', 'n+1', 'batch'],
                     ),
                 );
             }
@@ -688,6 +719,7 @@ class NPlusOneAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer\AnalyzerInte
         $typeLabel = match ($detectedType['type']) {
             'proxy' => 'Proxy N+1 (ManyToOne/OneToOne)',
             'collection' => $detectedType['hasLimit'] ? 'Collection N+1 with partial access' : 'Collection N+1 (OneToMany/ManyToMany)',
+            'lookup' => 'Repeated Lookup (findBy/findOneBy in loop)',
             default => 'N+1 Query',
         };
 
@@ -719,6 +751,8 @@ class NPlusOneAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer\AnalyzerInte
             $description .= "\nProxy initialization detected in a loop. Consider using a fetch join (join + addSelect) for better performance.";
         } elseif ('collection' === $detectedType['type'] && $detectedType['hasLimit']) {
             $description .= "\nDetected partial collection access (LIMIT in query). EXTRA_LAZY fetch mode is usually ideal here.";
+        } elseif ('lookup' === $detectedType['type']) {
+            $description .= "\nRepeated lookup by non-key column detected. Consider using an IN query to batch-load all needed rows, or add an in-memory cache to avoid duplicate queries within the same request.";
         }
 
         if ($isLowTimeHighCount) {

--- a/src/Analyzer/Security/HardcodedDatabaseCredentialsAnalyzer.php
+++ b/src/Analyzer/Security/HardcodedDatabaseCredentialsAnalyzer.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Doctor.
+ * (c) 2025-2026 Ahmed EBEN HASSINE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AhmedBhs\DoctrineDoctor\Analyzer\Security;
+
+use AhmedBhs\DoctrineDoctor\Collection\IssueCollection;
+use AhmedBhs\DoctrineDoctor\Collection\QueryDataCollection;
+use AhmedBhs\DoctrineDoctor\Factory\SuggestionFactoryInterface;
+use AhmedBhs\DoctrineDoctor\Issue\SecurityIssue;
+use AhmedBhs\DoctrineDoctor\Suggestion\SuggestionInterface;
+use AhmedBhs\DoctrineDoctor\ValueObject\Severity;
+use AhmedBhs\DoctrineDoctor\ValueObject\SuggestionMetadata;
+use AhmedBhs\DoctrineDoctor\ValueObject\SuggestionType;
+use Doctrine\DBAL\Connection;
+
+class HardcodedDatabaseCredentialsAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer\AnalyzerInterface
+{
+    private const string ENV_PATTERN = '/^%env\(.*\)%$/';
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly SuggestionFactoryInterface $suggestionFactory,
+    ) {
+    }
+
+    public function analyze(QueryDataCollection $queryDataCollection): IssueCollection
+    {
+        return IssueCollection::fromGenerator(
+            function () {
+                $params = $this->connection->getParams();
+
+                if (isset($params['url']) && \is_string($params['url'])) {
+                    if (!$this->isEnvVar($params['url'])) {
+                        $parsed = parse_url($params['url']);
+                        if (\is_array($parsed) && isset($parsed['user'])) {
+                            yield $this->createHardcodedUrlIssue($params['url']);
+                        }
+                    }
+
+                    return;
+                }
+
+                $hardcodedFields = [];
+
+                if (isset($params['user']) && \is_string($params['user']) && '' !== $params['user'] && !$this->isEnvVar($params['user'])) {
+                    $hardcodedFields[] = 'user';
+                }
+
+                if (isset($params['password']) && \is_string($params['password']) && '' !== $params['password'] && !$this->isEnvVar($params['password'])) {
+                    $hardcodedFields[] = 'password';
+                }
+
+                if (isset($params['host']) && \is_string($params['host']) && '' !== $params['host'] && !$this->isEnvVar($params['host']) && !\in_array($params['host'], ['localhost', '127.0.0.1', '::1'], true)) {
+                    $hardcodedFields[] = 'host';
+                }
+
+                if ([] !== $hardcodedFields) {
+                    yield $this->createHardcodedParamsIssue($hardcodedFields);
+                }
+            },
+        );
+    }
+
+    private function isEnvVar(string $value): bool
+    {
+        return 1 === preg_match(self::ENV_PATTERN, $value);
+    }
+
+    private function createHardcodedUrlIssue(string $url): SecurityIssue
+    {
+        $maskedUrl = preg_replace('/:([^@]+)@/', ':****@', $url);
+
+        return new SecurityIssue([
+            'title' => 'Hardcoded Database URL',
+            'description' => sprintf(
+                'The database URL is hardcoded in configuration instead of using an environment variable: "%s". '
+                . 'Hardcoded credentials can be leaked through version control, error pages, or config dumps. '
+                . 'Use %%env(DATABASE_URL)%% to reference environment variables.',
+                $maskedUrl,
+            ),
+            'severity' => 'critical',
+            'suggestion' => $this->createEnvVarSuggestion(),
+            'queries' => [],
+        ]);
+    }
+
+    private function createHardcodedParamsIssue(array $fields): SecurityIssue
+    {
+        return new SecurityIssue([
+            'title' => sprintf('Hardcoded Database Credentials: %s', implode(', ', $fields)),
+            'description' => sprintf(
+                'The following database connection parameters are hardcoded instead of using environment variables: %s. '
+                . 'Hardcoded credentials can be leaked through version control, error pages, or config dumps. '
+                . 'Use %%env()%% syntax in Symfony configuration to reference environment variables.',
+                implode(', ', $fields),
+            ),
+            'severity' => 'critical',
+            'suggestion' => $this->createEnvVarSuggestion(),
+            'queries' => [],
+        ]);
+    }
+
+    private function createEnvVarSuggestion(): SuggestionInterface
+    {
+        $code = "# In .env (not committed to VCS):\n";
+        $code .= "DATABASE_URL=\"mysql://app_user:secret@127.0.0.1:3306/my_database\"\n\n";
+        $code .= "# In config/packages/doctrine.yaml:\n";
+        $code .= "doctrine:\n";
+        $code .= "    dbal:\n";
+        $code .= "        url: '%env(resolve:DATABASE_URL)%'";
+
+        return $this->suggestionFactory->createFromTemplate(
+            templateName: 'Integrity/code_suggestion',
+            context: [
+                'description' => 'Move database credentials to environment variables',
+                'code' => $code,
+                'file_path' => 'config/packages/doctrine.yaml',
+            ],
+            suggestionMetadata: new SuggestionMetadata(
+                type: SuggestionType::security(),
+                severity: Severity::critical(),
+                title: 'Use Environment Variables for Database Credentials',
+                tags: ['security', 'credentials', 'owasp', 'configuration'],
+            ),
+        );
+    }
+}

--- a/src/Analyzer/Security/OverprivilegedDatabaseUserAnalyzer.php
+++ b/src/Analyzer/Security/OverprivilegedDatabaseUserAnalyzer.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Doctor.
+ * (c) 2025-2026 Ahmed EBEN HASSINE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AhmedBhs\DoctrineDoctor\Analyzer\Security;
+
+use AhmedBhs\DoctrineDoctor\Collection\IssueCollection;
+use AhmedBhs\DoctrineDoctor\Collection\QueryDataCollection;
+use AhmedBhs\DoctrineDoctor\Factory\SuggestionFactoryInterface;
+use AhmedBhs\DoctrineDoctor\Issue\SecurityIssue;
+use AhmedBhs\DoctrineDoctor\Suggestion\SuggestionInterface;
+use AhmedBhs\DoctrineDoctor\ValueObject\Severity;
+use AhmedBhs\DoctrineDoctor\ValueObject\SuggestionMetadata;
+use AhmedBhs\DoctrineDoctor\ValueObject\SuggestionType;
+use Doctrine\DBAL\Connection;
+
+class OverprivilegedDatabaseUserAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer\AnalyzerInterface
+{
+    private const array PRIVILEGED_USERS = ['root', 'postgres', 'admin', 'sa'];
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly SuggestionFactoryInterface $suggestionFactory,
+    ) {
+    }
+
+    public function analyze(QueryDataCollection $queryDataCollection): IssueCollection
+    {
+        return IssueCollection::fromGenerator(
+            function () {
+                $params = $this->connection->getParams();
+
+                $user = null;
+                $password = null;
+
+                if (isset($params['url']) && \is_string($params['url'])) {
+                    $parsed = parse_url($params['url']);
+                    if (\is_array($parsed)) {
+                        $user = isset($parsed['user']) ? urldecode($parsed['user']) : null;
+                        $password = isset($parsed['pass']) ? urldecode($parsed['pass']) : null;
+                    }
+                }
+
+                $user ??= $params['user'] ?? null;
+                $password ??= $params['password'] ?? null;
+
+                if (!\is_string($user) || '' === $user) {
+                    yield $this->createEmptyUserIssue();
+
+                    return;
+                }
+
+                if (\in_array(strtolower($user), self::PRIVILEGED_USERS, true)) {
+                    yield $this->createPrivilegedUserIssue($user);
+                }
+
+                if (null === $password || (\is_string($password) && '' === $password)) {
+                    yield $this->createEmptyPasswordIssue($user);
+                }
+            },
+        );
+    }
+
+    private function createPrivilegedUserIssue(string $user): SecurityIssue
+    {
+        return new SecurityIssue([
+            'title' => sprintf('Overprivileged Database User: %s', $user),
+            'description' => sprintf(
+                'The database connection uses the privileged user "%s". '
+                . 'This violates the principle of least privilege (OWASP). '
+                . 'A compromised application could be used to drop tables, create users, or access other databases. '
+                . 'Create a dedicated database user with only SELECT, INSERT, UPDATE, DELETE privileges on the application database.',
+                $user,
+            ),
+            'severity' => 'warning',
+            'suggestion' => $this->createLeastPrivilegeSuggestion($user),
+            'queries' => [],
+        ]);
+    }
+
+    private function createEmptyUserIssue(): SecurityIssue
+    {
+        return new SecurityIssue([
+            'title' => 'Empty Database User',
+            'description' => 'The database connection has no user configured. '
+                . 'This may indicate a misconfiguration or the use of a default anonymous connection. '
+                . 'Always use a named, dedicated user for database connections.',
+            'severity' => 'warning',
+            'suggestion' => $this->createLeastPrivilegeSuggestion('(empty)'),
+            'queries' => [],
+        ]);
+    }
+
+    private function createEmptyPasswordIssue(string $user): SecurityIssue
+    {
+        return new SecurityIssue([
+            'title' => sprintf('Empty Database Password for User: %s', $user),
+            'description' => sprintf(
+                'The database user "%s" has an empty password. '
+                . 'This is a critical security risk: anyone with network access to the database server can connect. '
+                . 'Set a strong password for all database users.',
+                $user,
+            ),
+            'severity' => 'critical',
+            'suggestion' => $this->createLeastPrivilegeSuggestion($user),
+            'queries' => [],
+        ]);
+    }
+
+    private function createLeastPrivilegeSuggestion(string $currentUser): SuggestionInterface
+    {
+        $code = "-- Create a dedicated database user with minimal privileges:\n";
+        $code .= "CREATE USER 'app_user'@'%' IDENTIFIED BY 'strong_random_password';\n";
+        $code .= "GRANT SELECT, INSERT, UPDATE, DELETE ON my_database.* TO 'app_user'@'%';\n";
+        $code .= "FLUSH PRIVILEGES;\n\n";
+        $code .= "# In .env:\n";
+        $code .= "DATABASE_URL=\"mysql://app_user:strong_random_password@127.0.0.1:3306/my_database\"";
+
+        return $this->suggestionFactory->createFromTemplate(
+            templateName: 'Integrity/code_suggestion',
+            context: [
+                'description' => sprintf('Replace "%s" with a dedicated, least-privilege database user', $currentUser),
+                'code' => $code,
+                'file_path' => '.env',
+            ],
+            suggestionMetadata: new SuggestionMetadata(
+                type: SuggestionType::security(),
+                severity: Severity::warning(),
+                title: 'Use Least-Privilege Database User',
+                tags: ['security', 'database', 'owasp', 'least-privilege'],
+            ),
+        );
+    }
+}

--- a/src/Analyzer/Security/SensitiveDataExposureAnalyzer.php
+++ b/src/Analyzer/Security/SensitiveDataExposureAnalyzer.php
@@ -193,6 +193,12 @@ class SensitiveDataExposureAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer
             if ($issue instanceof SecurityIssue) {
                 $issues[] = $issue;
             }
+
+            $getterIssue = $this->checkPublicGetter($entityClass, $sensitiveField, $reflectionClass);
+
+            if ($getterIssue instanceof SecurityIssue) {
+                $issues[] = $getterIssue;
+            }
         }
 
         return $issues;
@@ -404,6 +410,111 @@ class SensitiveDataExposureAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer
         }
 
         return null;
+    }
+
+    private function checkPublicGetter(
+        string $entityClass,
+        string $fieldName,
+        \ReflectionClass $reflectionClass,
+    ): ?SecurityIssue {
+        $getterNames = [
+            'get' . ucfirst($fieldName),
+            $fieldName,
+        ];
+
+        foreach ($getterNames as $getterName) {
+            if (!$reflectionClass->hasMethod($getterName)) {
+                continue;
+            }
+
+            $method = $reflectionClass->getMethod($getterName);
+
+            if (!$method->isPublic()) {
+                continue;
+            }
+
+            if ($method->getDeclaringClass()->getName() !== $entityClass) {
+                continue;
+            }
+
+            $hasProtection = false;
+            $attributes = $method->getAttributes();
+
+            foreach ($attributes as $attribute) {
+                if (str_contains($attribute->getName(), 'Ignore') || str_contains($attribute->getName(), 'SensitiveParameter')) {
+                    $hasProtection = true;
+                    break;
+                }
+            }
+
+            $docComment = $method->getDocComment();
+            if (false !== $docComment && (str_contains($docComment, '@internal') || str_contains($docComment, '@Ignore'))) {
+                $hasProtection = true;
+            }
+
+            if ($hasProtection) {
+                continue;
+            }
+
+            return new SecurityIssue([
+                'title' => sprintf('Public getter exposes sensitive field: %s::%s()', $this->shortClassName($entityClass), $getterName),
+                'description' => sprintf(
+                    'Entity "%s" has a public getter "%s()" that returns the sensitive field "$%s". '
+                    . 'Public getters on sensitive fields allow any caller to access raw sensitive data. '
+                    . 'Consider restricting visibility, adding #[Ignore] for serialization, '
+                    . 'or returning a masked/hashed value instead.',
+                    $this->shortClassName($entityClass),
+                    $getterName,
+                    $fieldName,
+                ),
+                'severity' => 'info',
+                'suggestion' => $this->createGetterSuggestion($entityClass, $fieldName, $getterName, $method),
+                'backtrace' => [
+                    'file' => $method->getFileName(),
+                    'line' => $method->getStartLine(),
+                ],
+                'queries' => [],
+            ]);
+        }
+
+        return null;
+    }
+
+    private function createGetterSuggestion(
+        string $entityClass,
+        string $fieldName,
+        string $getterName,
+        \ReflectionMethod $reflectionMethod,
+    ): SuggestionInterface {
+        $shortClassName = $this->shortClassName($entityClass);
+
+        $code = "// Option 1: Restrict access via Symfony Serializer\n";
+        $code .= "#[Ignore]\n";
+        $code .= "public function {$getterName}(): string\n";
+        $code .= "{\n";
+        $code .= "    return \$this->{$fieldName};\n";
+        $code .= "}\n\n";
+        $code .= "// Option 2: Return masked value for display\n";
+        $code .= "public function getMasked" . ucfirst($fieldName) . "(): string\n";
+        $code .= "{\n";
+        $code .= "    return str_repeat('*', max(0, strlen(\$this->{$fieldName}) - 4))\n";
+        $code .= "        . substr(\$this->{$fieldName}, -4);\n";
+        $code .= '}';
+
+        return $this->suggestionFactory->createFromTemplate(
+            templateName: 'Integrity/code_suggestion',
+            context: [
+                'description' => sprintf('Protect getter %s::%s() from exposing sensitive data', $shortClassName, $getterName),
+                'code' => $code,
+                'file_path' => $this->getFileLocation($reflectionMethod),
+            ],
+            suggestionMetadata: new SuggestionMetadata(
+                type: SuggestionType::security(),
+                severity: Severity::info(),
+                title: sprintf('Protect Sensitive Getter %s::%s()', $shortClassName, $getterName),
+                tags: ['security', 'sensitive-data', 'getter'],
+            ),
+        );
     }
 
     private function createToStringSuggestion(string $entityClass, \ReflectionMethod $reflectionMethod): SuggestionInterface

--- a/src/Template/Suggestions/Integrity/collection_initialization.php
+++ b/src/Template/Suggestions/Integrity/collection_initialization.php
@@ -10,11 +10,12 @@ $entityClass = (string) ($context['entity_class'] ?? 'Entity');
 $fieldName = (string) ($context['field_name'] ?? 'items');
 $targetEntity = (string) ($context['target_entity'] ?? 'Item');
 $associationType = (string) ($context['association_type'] ?? 'OneToMany');
+$mappedByValue = (string) ($context['mapped_by'] ?? 'yourPropertyName');
 $hasConstructor = (bool) ($context['has_constructor'] ?? false);
 $e = fn (?string $str): string => htmlspecialchars($str ?? '', ENT_QUOTES, 'UTF-8');
 $lastBackslash = strrchr($entityClass, '\\');
 $shortClass = false !== $lastBackslash ? substr($lastBackslash, 1) : $entityClass;
-$mappedBy = 'OneToMany' === $associationType ? ", mappedBy: 'parent'" : '';
+$mappedBy = 'OneToMany' === $associationType ? ", mappedBy: '" . $mappedByValue . "'" : '';
 ob_start();
 ?>
 <div class="suggestion-header"><h4>Uninitialized collection</h4></div>

--- a/src/Template/Suggestions/Performance/repeated_lookup.php
+++ b/src/Template/Suggestions/Performance/repeated_lookup.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Variables provided by PhpTemplateRenderer::extract($context)
+ * @var mixed $entity
+ * @var mixed $column
+ * @var mixed $queryCount
+ * @var mixed $triggerLocation
+ * @var mixed $context
+ */
+['entity' => $entity, 'column' => $column, 'query_count' => $queryCount, 'trigger_location' => $triggerLocation] = $context;
+
+$e = fn (?string $str): string => htmlspecialchars($str ?? '', ENT_QUOTES, 'UTF-8');
+
+ob_start();
+?>
+
+<div class="suggestion-header">
+    <h4>Repeated Lookup Query Problem</h4>
+</div>
+
+<div class="suggestion-content">
+    <div class="alert alert-warning">
+        <strong>Repeated Lookup Detected</strong><br>
+        Detected <strong><?php echo $queryCount; ?> sequential queries</strong> looking up <code><?php echo $e($entity); ?></code> by <code><?php echo $e($column); ?></code>.
+        This happens when calling <code>findBy()</code> or <code>findOneBy()</code> repeatedly with different values for the same column.
+    </div>
+
+<?php if (null !== $triggerLocation && '' !== $triggerLocation): ?>
+    <div class="alert alert-info">
+        <strong>Triggered at:</strong> <code><?php echo $e($triggerLocation); ?></code>
+    </div>
+<?php endif; ?>
+
+    <h4>Problem: Repeated findBy/findOneBy in Loop</h4>
+    <div class="query-item">
+        <pre><code class="language-php">foreach ($values as $value) {
+    $entity = $repository->findOneBy(['<?php echo $e($column); ?>' => $value]); // Query triggered here!
+}
+// Result: <?php echo $queryCount; ?> queries instead of 1</code></pre>
+    </div>
+
+    <h4>Solution 1: Batch Load with IN Query</h4>
+    <div class="query-item">
+        <pre><code class="language-php">$entities = $repository->createQueryBuilder('e')
+    ->where('e.<?php echo $e($column); ?> IN (:values)')
+    ->setParameter('values', $allValues)
+    ->getQuery()
+    ->getResult();
+
+// Index by <?php echo $e($column); ?> for O(1) access
+$indexed = [];
+foreach ($entities as $entity) {
+    $indexed[$entity->get<?php echo ucfirst((string) $column); ?>()] = $entity;
+}
+// Result: 1 query instead of <?php echo $queryCount; ?></code></pre>
+    </div>
+
+    <h4>Solution 2: In-Memory Cache</h4>
+    <div class="query-item">
+        <pre><code class="language-php">private array $cache = [];
+
+public function getBy<?php echo ucfirst((string) $column); ?>(string $<?php echo $e($column); ?>): ?<?php echo $e($entity); ?>
+
+{
+    if (array_key_exists($<?php echo $e($column); ?>, $this->cache)) {
+        return $this->cache[$<?php echo $e($column); ?>];
+    }
+
+    $entity = $this->repository->findOneBy(['<?php echo $e($column); ?>' => $<?php echo $e($column); ?>]);
+    $this->cache[$<?php echo $e($column); ?>] = $entity;
+
+    return $entity;
+}</code></pre>
+    </div>
+
+    <div class="alert alert-info">
+        <strong>Expected improvement:</strong><br>
+        <ul>
+            <li><strong>Current:</strong> <?php echo $queryCount; ?> queries (one per lookup value)</li>
+            <li><strong>With IN query:</strong> 1 query total</li>
+            <li><strong>With cache:</strong> max 1 query per unique value</li>
+        </ul>
+    </div>
+</div>
+
+<?php
+$code = ob_get_clean();
+
+return [
+    'code'        => $code,
+    'description' => sprintf(
+        'Repeated lookup on %s.%s - batch with IN query or add in-memory cache',
+        $entity,
+        $column,
+    ),
+];

--- a/tests/Analyzer/Performance/RepeatedLookupDetectionTest.php
+++ b/tests/Analyzer/Performance/RepeatedLookupDetectionTest.php
@@ -1,0 +1,280 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Doctor.
+ * (c) 2025-2026 Ahmed EBEN HASSINE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AhmedBhs\DoctrineDoctor\Tests\Analyzer\Performance;
+
+use AhmedBhs\DoctrineDoctor\Analyzer\Parser\SqlPatternDetector;
+use AhmedBhs\DoctrineDoctor\Analyzer\Performance\NPlusOneAnalyzer;
+use AhmedBhs\DoctrineDoctor\Tests\Integration\PlatformAnalyzerTestHelper;
+use AhmedBhs\DoctrineDoctor\Tests\Support\QueryDataBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+final class RepeatedLookupDetectionTest extends TestCase
+{
+    private NPlusOneAnalyzer $analyzer;
+
+    private SqlPatternDetector $patternDetector;
+
+    protected function setUp(): void
+    {
+        $entityManager = PlatformAnalyzerTestHelper::createTestEntityManager([
+            __DIR__ . '/../../Fixtures/Entity',
+        ]);
+
+        $this->analyzer = new NPlusOneAnalyzer(
+            $entityManager,
+            PlatformAnalyzerTestHelper::createIssueFactory(),
+            PlatformAnalyzerTestHelper::createSuggestionFactory(),
+            5,
+        );
+
+        $this->patternDetector = new SqlPatternDetector();
+    }
+
+    #[Test]
+    public function it_detects_repeated_lookup_by_slug(): void
+    {
+        $builder = QueryDataBuilder::create();
+
+        for ($i = 0; $i < 5; ++$i) {
+            $builder->addQuery(
+                'SELECT t0.id AS id_1, t0.slug AS slug_2, t0.value AS value_3 FROM configuration_item t0 WHERE t0.slug = ?',
+                0.5,
+            );
+        }
+
+        $issues = $this->analyzer->analyze($builder->build());
+        $issuesArray = $issues->toArray();
+
+        self::assertCount(1, $issuesArray);
+        self::assertStringContainsString('lookup', $issuesArray[0]->getTitle());
+    }
+
+    #[Test]
+    public function it_detects_repeated_lookup_by_email(): void
+    {
+        $builder = QueryDataBuilder::create();
+
+        for ($i = 0; $i < 6; ++$i) {
+            $builder->addQuery(
+                'SELECT t0.id AS id_1, t0.email AS email_2, t0.name AS name_3 FROM users t0 WHERE t0.email = ?',
+                0.3,
+            );
+        }
+
+        $issues = $this->analyzer->analyze($builder->build());
+        $issuesArray = $issues->toArray();
+
+        self::assertCount(1, $issuesArray);
+        self::assertStringContainsString('lookup', $issuesArray[0]->getTitle());
+    }
+
+    #[Test]
+    public function it_detects_repeated_lookup_by_code(): void
+    {
+        $builder = QueryDataBuilder::create();
+
+        for ($i = 0; $i < 5; ++$i) {
+            $builder->addQuery(
+                'SELECT t0.id AS id_1, t0.code AS code_2 FROM country t0 WHERE t0.code = ?',
+                0.2,
+            );
+        }
+
+        $issues = $this->analyzer->analyze($builder->build());
+
+        self::assertCount(1, $issues->toArray());
+    }
+
+    #[Test]
+    public function it_includes_lookup_description_with_actionable_advice(): void
+    {
+        $builder = QueryDataBuilder::create();
+
+        for ($i = 0; $i < 5; ++$i) {
+            $builder->addQuery(
+                'SELECT t0.id AS id_1, t0.slug AS slug_2 FROM configuration_item t0 WHERE t0.slug = ?',
+                0.5,
+            );
+        }
+
+        $issues = $this->analyzer->analyze($builder->build());
+        $issuesArray = $issues->toArray();
+
+        self::assertStringContainsString('Repeated Lookup', $issuesArray[0]->getDescription());
+        self::assertStringContainsString('IN query', $issuesArray[0]->getDescription());
+    }
+
+    // --- Pattern Detector unit tests ---
+
+    #[Test]
+    public function pattern_detector_detects_slug_lookup(): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern(
+            'SELECT t0.id AS id_1, t0.slug AS slug_2 FROM configuration_item t0 WHERE t0.slug = ?',
+        );
+
+        self::assertNotNull($result);
+        self::assertSame('configuration_item', $result['table']);
+        self::assertSame('slug', $result['column']);
+    }
+
+    #[Test]
+    public function pattern_detector_detects_email_lookup(): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern(
+            "SELECT t0.id FROM users t0 WHERE t0.email = 'test@example.com'",
+        );
+
+        self::assertNotNull($result);
+        self::assertSame('users', $result['table']);
+        self::assertSame('email', $result['column']);
+    }
+
+    // --- False positive prevention ---
+
+    #[Test]
+    public function it_does_not_classify_id_lookup_as_repeated_lookup(): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern(
+            'SELECT t0.id AS id_1, t0.name AS name_2 FROM users t0 WHERE t0.id = ?',
+        );
+
+        self::assertNull($result, 'WHERE id = ? should be classified as proxy, not lookup');
+    }
+
+    #[Test]
+    public function it_does_not_classify_foreign_key_as_repeated_lookup(): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern(
+            'SELECT t0.id AS id_1, t0.title AS title_2 FROM articles t0 WHERE t0.category_id = ?',
+        );
+
+        self::assertNull($result, 'WHERE category_id = ? should be classified as collection N+1, not lookup');
+    }
+
+    #[Test]
+    public function it_does_not_classify_query_with_joins_as_repeated_lookup(): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern(
+            'SELECT t0.id FROM users t0 INNER JOIN user_role ur ON t0.id = ur.user_id WHERE t0.email = ?',
+        );
+
+        self::assertNull($result, 'Query with JOINs should not be classified as simple repeated lookup');
+    }
+
+    #[Test]
+    public function it_does_not_classify_query_without_where_as_repeated_lookup(): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern(
+            'SELECT t0.id, t0.slug FROM configuration_item t0',
+        );
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function it_does_not_classify_multi_condition_where_as_repeated_lookup(): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern(
+            'SELECT t0.id FROM users t0 WHERE t0.email = ? AND t0.status = ?',
+        );
+
+        self::assertNull($result, 'Multi-condition WHERE with two non-key columns should not match');
+    }
+
+    #[Test]
+    public function it_does_not_detect_below_threshold(): void
+    {
+        $builder = QueryDataBuilder::create();
+
+        for ($i = 0; $i < 4; ++$i) {
+            $builder->addQuery(
+                'SELECT t0.id AS id_1, t0.slug AS slug_2 FROM configuration_item t0 WHERE t0.slug = ?',
+                0.5,
+            );
+        }
+
+        $issues = $this->analyzer->analyze($builder->build());
+
+        self::assertCount(0, $issues->toArray(), 'Should not detect N+1 below threshold of 5');
+    }
+
+    #[Test]
+    public function it_does_not_classify_insert_as_repeated_lookup(): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern(
+            "INSERT INTO configuration_item (slug, value) VALUES ('test', 'value')",
+        );
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function it_does_not_classify_update_as_repeated_lookup(): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern(
+            "UPDATE configuration_item SET value = 'new' WHERE slug = 'test'",
+        );
+
+        self::assertNull($result);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function nonLookupColumnProvider(): array
+    {
+        return [
+            'primary key id' => ['SELECT t0.id FROM users t0 WHERE t0.id = ?'],
+            'foreign key user_id' => ['SELECT t0.id FROM orders t0 WHERE t0.user_id = ?'],
+            'foreign key category_id' => ['SELECT t0.id FROM articles t0 WHERE t0.category_id = ?'],
+            'foreign key parent_id' => ['SELECT t0.id FROM categories t0 WHERE t0.parent_id = ?'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('nonLookupColumnProvider')]
+    public function it_does_not_match_id_or_foreign_key_columns(string $sql): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern($sql);
+
+        self::assertNull($result, sprintf('Should not classify as lookup: %s', $sql));
+    }
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function lookupColumnProvider(): array
+    {
+        return [
+            'slug column' => ['SELECT t0.id FROM items t0 WHERE t0.slug = ?', 'items', 'slug'],
+            'email column' => ['SELECT t0.id FROM users t0 WHERE t0.email = ?', 'users', 'email'],
+            'code column' => ['SELECT t0.id FROM countries t0 WHERE t0.code = ?', 'countries', 'code'],
+            'username column' => ['SELECT t0.id FROM users t0 WHERE t0.username = ?', 'users', 'username'],
+            'token column' => ['SELECT t0.id FROM sessions t0 WHERE t0.token = ?', 'sessions', 'token'],
+            'locale column' => ['SELECT t0.id FROM translations t0 WHERE t0.locale = ?', 'translations', 'locale'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('lookupColumnProvider')]
+    public function it_detects_common_lookup_columns(string $sql, string $expectedTable, string $expectedColumn): void
+    {
+        $result = $this->patternDetector->detectRepeatedLookupPattern($sql);
+
+        self::assertNotNull($result, sprintf('Should detect lookup pattern for: %s', $sql));
+        self::assertSame($expectedTable, $result['table']);
+        self::assertSame($expectedColumn, $result['column']);
+    }
+}

--- a/tests/Unit/Template/Renderer/TemplateValidationTest.php
+++ b/tests/Unit/Template/Renderer/TemplateValidationTest.php
@@ -312,6 +312,32 @@ final class TemplateValidationTest extends TestCase
         self::assertStringContainsString($expectedShortName, $result['description']);
     }
 
+    public function test_collection_initialization_uses_mapped_by_context_for_one_to_many(): void
+    {
+        $result = $this->renderer->render('Integrity/collection_initialization', [
+            'entity_class' => 'App\\Entity\\Order',
+            'field_name' => 'items',
+            'target_entity' => 'OrderItem',
+            'association_type' => 'OneToMany',
+            'mapped_by' => 'order',
+        ]);
+
+        self::assertStringContainsString("mappedBy: 'order'", $result['code']);
+        self::assertStringNotContainsString("mappedBy: 'parent'", $result['code']);
+    }
+
+    public function test_collection_initialization_falls_back_to_placeholder_without_mapped_by(): void
+    {
+        $result = $this->renderer->render('Integrity/collection_initialization', [
+            'entity_class' => 'App\\Entity\\Order',
+            'field_name' => 'items',
+            'target_entity' => 'OrderItem',
+            'association_type' => 'OneToMany',
+        ]);
+
+        self::assertStringContainsString("mappedBy: 'yourPropertyName'", $result['code']);
+    }
+
     public function test_dto_hydration_handles_missing_aggregations(): void
     {
         $result = $this->renderer->render('Performance/dto_hydration', [


### PR DESCRIPTION
## Summary

- add two security analyzers to detect hardcoded database credentials and overprivileged database users
- detect repeated non-key lookups in loops and report them as a dedicated N+1 pattern with actionable suggestions
- improve integrity suggestions by using the real `mappedBy` value and by attaching fixes to property type mismatch findings
- extend sensitive data exposure analysis to flag public getters on sensitive fields


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added security analysis for hardcoded database credentials and overprivileged database users
  * Implemented repeated lookup pattern detection to identify N+1 query performance issues
  * Enhanced detection of sensitive data exposure through public getter methods

* **Improvements**
  * Enhanced type-mismatch analysis with improved suggestions
  * Improved suggestion rendering with dynamic context values
  * Expanded SQL pattern detection capabilities with optimized caching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->