### PR TITLE
fix(security): prevent XSS in backtrace JSON output

### DIFF
--- a/templates/profiler/doctrine_doctor.html.twig
+++ b/templates/profiler/doctrine_doctor.html.twig
@@ -190,7 +190,7 @@
             {% if issue.getBacktrace() %}
                 <div id="{{ prefix }}-backtrace-{{ loop_index }}" class="dd-collapsible hidden">
                     <div class="backtrace-content">
-                        <pre>{{ issue.getBacktrace()|json_encode(constant('JSON_PRETTY_PRINT'))|raw }}</pre>
+                        <pre>{{ issue.getBacktrace()|json_encode(constant('JSON_PRETTY_PRINT') b-or constant('JSON_HEX_TAG') b-or constant('JSON_HEX_AMP'))|raw }}</pre>
                     </div>
                 </div>
             {% endif %}


### PR DESCRIPTION
Add JSON_HEX_TAG and JSON_HEX_AMP flags to json_encode in profiler template to neutralize HTML tags in backtrace file paths.
Closes #25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering of special characters in JSON backtraces within the profiler tool to prevent display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->