### PR TITLE
fix: prevent false positive in MissingIndexAnalyzer when index is used

### DIFF
--- a/src/Analyzer/Performance/MissingIndexAnalyzer.php
+++ b/src/Analyzer/Performance/MissingIndexAnalyzer.php
@@ -518,6 +518,10 @@ class MissingIndexAnalyzer implements \AhmedBhs\DoctrineDoctor\Analyzer\Analyzer
             return $rows >= $this->missingIndexAnalyzerConfig->minRowsScanned;
         }
 
+        if (null !== $key) {
+            return false;
+        }
+
         return $rows >= $this->missingIndexAnalyzerConfig->minRowsScanned;
     }
 


### PR DESCRIPTION
The fallback in shouldSuggestIndex() flagged queries regardless of whether an index was effectively used. Access types like FULLTEXT or REF_OR_NULL with a valid key were incorrectly suggested for indexing.

Skip suggestion when an index key is already in use.

Closes #30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance analyzer index suggestion logic to better handle scenarios where an index already exists, reducing unnecessary index recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->