### PR TITLE
Report measured facts in the setMaxResults collection join alert, and fix hasOffset()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.10.1] - 2026-08-19
+
+### Changed
+
+- The `setMaxResults() with Collection Join` alert now carries the facts of the query that triggered it instead of a fixed block of theory: the LIMIT value and the number of fetch-joined tables, the row count when the profiler reports one, and an explicit note when a result set reached its LIMIT and was therefore very likely truncated in the middle of a root entity. When the query is offset past the first page, the alert also warns that a batch loop bounded by a root entity count can exit early and never read the remaining entities — whole entities lost, not just collection items. Both remediations are given, paginating on identifiers and `Paginator`, with the trade-off between them. Every enrichment degrades to the base message when no row count is available, so the alert stays complete either way. Detection logic is unchanged.
+
+### Fixed
+
+- `hasOffset()` reported an offset for every `LIMIT` query. The SQL parser exposes an offset of `0` for a bare `LIMIT`, and the guard tested it with `'' !== (string) $offset`, which holds for `"0"`; the standalone-`OFFSET` regex fallback matched `OFFSET 0` for the same reason. It now compares against `0` and ignores a zero offset, so it answers whether the query is actually past the first page. `PaginationWithoutOrderByAnalyzer` derives its severity from this call, so a plain `LIMIT` without `ORDER BY` was reported as `LIMIT/OFFSET pagination` at `warning` instead of `LIMIT` at `info`; both cases are now reported correctly. `OrderByWithoutLimitAnalyzer` is unaffected. The method had no test coverage; a case per pagination form was added, including MySQL comma syntax and explicit zero offsets.
+
 ## [2.10.0] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- CI could not install dependencies on any branch. `composer.lock` is not tracked, so every run resolves afresh, and CVE-2026-53965 (reported 2026-08-14) covers `mcp/sdk` `>=0.5.0,<0.7.1`. `symfony/ai-symfony-mate-extension` was pinned to `^0.10`, whose `ai-mate` v0.10 requires `mcp/sdk ^0.6` exclusively, leaving no resolvable set. The constraint now allows `^0.11|^0.12`, which accept `mcp/sdk ^0.6|^0.7` and reach the patched v0.7.1.
+- Five pre-existing single-letter closure parameters started failing the PHPMD job: `phpmd/phpmd` is required as `3.x-dev`, and PHPMD 3 applies `ShortVariable` to closure parameters where 2.15 did not. Renamed rather than widening the ruleset exceptions.
+- A duplicate `case 'not_snake_case'` in the naming convention test's severity switch was unreachable dead code, reported by newer PHPStan as `switch.duplicateCase`. Removed; behaviour is unchanged.
 - `hasOffset()` reported an offset for every `LIMIT` query. The SQL parser exposes an offset of `0` for a bare `LIMIT`, and the guard tested it with `'' !== (string) $offset`, which holds for `"0"`; the standalone-`OFFSET` regex fallback matched `OFFSET 0` for the same reason. It now compares against `0` and ignores a zero offset, so it answers whether the query is actually past the first page. `PaginationWithoutOrderByAnalyzer` derives its severity from this call, so a plain `LIMIT` without `ORDER BY` was reported as `LIMIT/OFFSET pagination` at `warning` instead of `LIMIT` at `info`; both cases are now reported correctly. `OrderByWithoutLimitAnalyzer` is unaffected. The method had no test coverage; a case per pagination form was added, including MySQL comma syntax and explicit zero offsets.
 
 ## [2.10.0] - 2026-07-30

--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
     "phpstan/phpstan-symfony": "^2.0",
     "phpunit/phpunit": "^10.0",
     "rector/rector": "^2.3",
-    "symfony/ai-symfony-mate-extension": "^0.10",
+    "symfony/ai-symfony-mate-extension": "^0.10|^0.11|^0.12",
     "symfony/stopwatch": "^6.0|^7.0|^8.0",
     "symfony/validator": "^8.0",
     "symfony/var-dumper": "^6.0|^7.0|^8.0",

--- a/src/Analyzer/Integrity/ClassTableInheritanceDepthAnalyzer.php
+++ b/src/Analyzer/Integrity/ClassTableInheritanceDepthAnalyzer.php
@@ -92,7 +92,7 @@ class ClassTableInheritanceDepthAnalyzer implements MetadataAnalyzerInterface
                         'root_fqcn' => $rootClass,
                         'depth' => $depth,
                         'joins_required' => $joinsRequired,
-                        'chain' => array_map(fn (string $c): string => $this->shortClassName($c), $chain),
+                        'chain' => array_map(fn (string $className): string => $this->shortClassName($className), $chain),
                     ],
                     new SuggestionMetadata(
                         SuggestionType::integrity(),

--- a/src/Analyzer/Integrity/DenormalizedAggregateWithoutLockingAnalyzer.php
+++ b/src/Analyzer/Integrity/DenormalizedAggregateWithoutLockingAnalyzer.php
@@ -217,8 +217,8 @@ class DenormalizedAggregateWithoutLockingAnalyzer implements MetadataAnalyzerInt
             [
                 'class' => $shortName,
                 'method' => $method->getName(),
-                'fields' => implode(', ', array_map(fn (string $f): string => '$' . $f, $mutatedFields)),
-                'collections' => implode(', ', array_map(fn (string $c): string => '$' . $c, $accessedCollections)),
+                'fields' => implode(', ', array_map(fn (string $field): string => '$' . $field, $mutatedFields)),
+                'collections' => implode(', ', array_map(fn (string $collection): string => '$' . $collection, $accessedCollections)),
             ],
         );
 

--- a/src/Analyzer/Parser/SqlPerformanceAnalyzer.php
+++ b/src/Analyzer/Parser/SqlPerformanceAnalyzer.php
@@ -57,17 +57,20 @@ final class SqlPerformanceAnalyzer implements PerformanceAnalyzerInterface
             return false;
         }
 
-        // Check if OFFSET is part of LIMIT clause
+        // Check if OFFSET is part of LIMIT clause.
+        // The parser reports offset 0 for a bare LIMIT, so an offset only counts
+        // when it actually skips rows. Treating 0 as an offset would make this
+        // method true for every LIMIT query.
         if (null !== $statement->limit) {
             $limitOffset = $statement->limit->offset ?? null;
-            if (null !== $limitOffset && '' !== (string) $limitOffset) {
+            if (null !== $limitOffset && 0 !== (int) $limitOffset) {
                 return true;
             }
         }
 
         // Fallback: Some SQL dialects allow standalone OFFSET
         // The parser may not catch it, so use regex as backup
-        return 1 === preg_match('/\bOFFSET\b/i', $sql);
+        return 1 === preg_match('/\bOFFSET\s+(?!0+\b)\d+/i', $sql);
     }
 
     /**

--- a/src/Analyzer/Performance/GedmoExtensionPerformanceAnalyzer.php
+++ b/src/Analyzer/Performance/GedmoExtensionPerformanceAnalyzer.php
@@ -64,11 +64,11 @@ class GedmoExtensionPerformanceAnalyzer implements MetadataAnalyzerInterface
                         }
 
                         $entityClass = $metadata->getName();
-                        $rc = new ReflectionClass($entityClass);
+                        $reflection = new ReflectionClass($entityClass);
 
-                        if ($this->isLoggable($rc)) {
+                        if ($this->isLoggable($reflection)) {
                             yield $this->createLoggableIssue($entityClass);
-                        } elseif ($this->isTranslatable($rc)) {
+                        } elseif ($this->isTranslatable($reflection)) {
                             yield $this->createTranslatableIssue($entityClass);
                         }
                     }

--- a/src/Analyzer/Performance/NPlusOneSqlAnalyzer.php
+++ b/src/Analyzer/Performance/NPlusOneSqlAnalyzer.php
@@ -39,7 +39,7 @@ final class NPlusOneSqlAnalyzer implements AnalyzerInterface
     public function analyze(QueryDataCollection $queryDataCollection): IssueCollection
     {
         $selects = $queryDataCollection->filter(
-            fn (QueryData $q): bool => $this->sqlExtractor->isSelectQuery($q->sql),
+            fn (QueryData $query): bool => $this->sqlExtractor->isSelectQuery($query->sql),
         );
 
         $groups = $selects->groupByPattern(

--- a/src/Analyzer/Performance/SetMaxResultsWithCollectionJoinAnalyzer.php
+++ b/src/Analyzer/Performance/SetMaxResultsWithCollectionJoinAnalyzer.php
@@ -304,7 +304,7 @@ class SetMaxResultsWithCollectionJoinAnalyzer implements \AhmedBhs\DoctrineDocto
             $lines[] = $fact;
         }
 
-        if ($this->hasNonZeroOffset($sql)) {
+        if ($this->sqlExtractor->hasOffset($sql)) {
             $lines[] = 'Impact: this query also carries a non-zero OFFSET, so it is part of a paginated '
                 . 'walk. OFFSET counts rows, not root entities: a batch loop whose bound comes from a '
                 . 'root-entity count can exit early and never read the remaining root entities at all. '
@@ -316,22 +316,6 @@ class SetMaxResultsWithCollectionJoinAnalyzer implements \AhmedBhs\DoctrineDocto
             . 'with $fetchJoinCollection = true.';
 
         return implode("\n", $lines);
-    }
-
-    /**
-     * SqlStructureExtractor::hasOffset() reports true for any LIMIT clause,
-     * because the parser exposes a default offset of 0. We need the stricter
-     * question -- is this query actually offset past the first page -- so we
-     * read the offset value itself.
-     */
-    private function hasNonZeroOffset(string $sql): bool
-    {
-        if (1 === preg_match('/\bOFFSET\s+(\d+)/i', $sql, $matches)) {
-            return '0' !== $matches[1] && 0 !== (int) $matches[1];
-        }
-
-        return 1 === preg_match('/\bLIMIT\s+(\d+)\s*,\s*(\d+)/i', $sql, $matches)
-            && 0 !== (int) $matches[1];
     }
 
     /**

--- a/src/Analyzer/Performance/SetMaxResultsWithCollectionJoinAnalyzer.php
+++ b/src/Analyzer/Performance/SetMaxResultsWithCollectionJoinAnalyzer.php
@@ -44,7 +44,27 @@ use Doctrine\ORM\Mapping\ClassMetadata;
  *    ->setMaxResults(1);
  * ```
  * If Pet has 4 pictures, only 1 picture will be loaded due to LIMIT 1.
- * Solution: Use Doctrine's Paginator
+ * The severe variant adds setFirstResult() to build a batch loop:
+ * ```php
+ * $total = $repository->count([]);
+ * while ($offset < $total) {
+ *     $rows = $qb->leftJoin('r.tags', 't')->addSelect('t')
+ *         ->setFirstResult($offset)->setMaxResults(200)->getQuery()->getResult();
+ *     $offset += 200;
+ * }
+ * ```
+ * Here OFFSET walks over joined rows while $total counts root entities. With a
+ * row multiplication factor above 1 the loop exits after the first pass and the
+ * remaining root entities are never read at all: whole entities disappear, not
+ * just collection items.
+ * Solution: paginate on root identifiers, then fetch-join that batch
+ * ```php
+ * $ids = $qb->select('r.id')->setFirstResult($offset)->setMaxResults(200)
+ *     ->getQuery()->getSingleColumnResult();
+ * $rows = $qb2->leftJoin('r.tags', 't')->addSelect('t')
+ *     ->where('r.id IN (:ids)')->setParameter('ids', $ids)->getQuery()->getResult();
+ * ```
+ * Or use Doctrine's Paginator, which issues the identifier query for you
  * ```php
  * $paginator = new Paginator($query, $fetchJoinCollection = true);
  * ```
@@ -252,10 +272,7 @@ class SetMaxResultsWithCollectionJoinAnalyzer implements \AhmedBhs\DoctrineDocto
         $issueData = new IssueData(
             type: IssueType::SET_MAX_RESULTS_WITH_COLLECTION_JOIN->value,
             title: 'setMaxResults() with Collection Join Detected',
-            description: 'LIMIT is used with a fetch-joined collection.' . "\n" .
-            'Impact: LIMIT is applied to SQL rows, not root entities.' . "\n" .
-            'Impact: Collections may be partially hydrated (silent data loss).' . "\n" .
-            'Impact: Result counts and application behavior may become incorrect.',
+            description: $this->buildDescription($queryData),
             severity: Severity::critical(),
             suggestion: $this->createSuggestion($mainTable),
             queries: [$queryData],
@@ -263,6 +280,89 @@ class SetMaxResultsWithCollectionJoinAnalyzer implements \AhmedBhs\DoctrineDocto
         );
 
         return $this->issueFactory->create($issueData);
+    }
+
+    /**
+     * Build the issue description, enriched with the measured facts of this
+     * query whenever they are available.
+     * The base text is always present so the message stays complete when the
+     * profiler gives us no row count (rowCount is nullable) and when the query
+     * carries no OFFSET.
+     */
+    private function buildDescription(QueryData $queryData): string
+    {
+        $sql = $queryData->sql;
+
+        $lines = [
+            'LIMIT is used with a fetch-joined collection.',
+            'Impact: LIMIT is applied to SQL rows, not root entities.',
+            'Impact: Collections may be partially hydrated (silent data loss).',
+            'Impact: Result counts and application behavior may become incorrect.',
+        ];
+
+        foreach ($this->buildMeasuredFacts($queryData, $sql) as $fact) {
+            $lines[] = $fact;
+        }
+
+        if ($this->hasNonZeroOffset($sql)) {
+            $lines[] = 'Impact: this query also carries a non-zero OFFSET, so it is part of a paginated '
+                . 'walk. OFFSET counts rows, not root entities: a batch loop whose bound comes from a '
+                . 'root-entity count can exit early and never read the remaining root entities at all. '
+                . 'That loses whole entities, not just collection items.';
+        }
+
+        $lines[] = 'Fix: paginate on root entity identifiers, then fetch-join that batch '
+            . '(WHERE id IN (:ids)), or wrap the query in Doctrine\ORM\Tools\Pagination\Paginator '
+            . 'with $fetchJoinCollection = true.';
+
+        return implode("\n", $lines);
+    }
+
+    /**
+     * SqlStructureExtractor::hasOffset() reports true for any LIMIT clause,
+     * because the parser exposes a default offset of 0. We need the stricter
+     * question -- is this query actually offset past the first page -- so we
+     * read the offset value itself.
+     */
+    private function hasNonZeroOffset(string $sql): bool
+    {
+        if (1 === preg_match('/\bOFFSET\s+(\d+)/i', $sql, $matches)) {
+            return '0' !== $matches[1] && 0 !== (int) $matches[1];
+        }
+
+        return 1 === preg_match('/\bLIMIT\s+(\d+)\s*,\s*(\d+)/i', $sql, $matches)
+            && 0 !== (int) $matches[1];
+    }
+
+    /**
+     * @return string[]
+     */
+    private function buildMeasuredFacts(QueryData $queryData, string $sql): array
+    {
+        $facts = [];
+        $limit = $this->sqlExtractor->getLimitValue($sql);
+        $joinCount = $this->sqlExtractor->countJoins($sql);
+        $rowCount = $queryData->rowCount;
+
+        if (null !== $limit) {
+            $facts[] = sprintf('Observed: LIMIT %d applied across %d fetch-joined table(s).', $limit, $joinCount);
+        }
+
+        if (null === $limit || null === $rowCount) {
+            return $facts;
+        }
+
+        $facts[] = sprintf('Observed: the database returned %d row(s) for this LIMIT %d.', $rowCount, $limit);
+
+        if ($rowCount >= $limit) {
+            $facts[] = sprintf(
+                'Observed: the row count reached the LIMIT, so the result set was very likely '
+                . 'truncated in the middle of a root entity. Fewer than %d root entities were hydrated.',
+                $limit,
+            );
+        }
+
+        return $facts;
     }
 
     private function createSuggestion(string $entityHint): SuggestionInterface

--- a/src/Template/Suggestions/Performance/setMaxResults_with_collection_join.php
+++ b/src/Template/Suggestions/Performance/setMaxResults_with_collection_join.php
@@ -25,21 +25,69 @@ ob_start();
         <strong>Data loss risk</strong> - <code>setMaxResults()</code> with fetch-joined collections applies LIMIT to SQL rows, not entities, causing incomplete collections.
     </div>
 
-    <p>LIMIT applies to rows, not entities. If an order has 5 items, you might only get 2.</p>
+    <p>
+        A fetch-joined to-many association returns one SQL row per combination, so
+        <code>N</code> root entities become <code>N &times; factor</code> rows. LIMIT cuts that
+        row stream, not the entity list. Detected on <code><?php echo $e(is_string($entityHint) ? $entityHint : 'entity'); ?></code>.
+    </p>
 
-    <h4>Current (incomplete)</h4>
+    <h4>Symptom 1: truncated collections</h4>
     <pre><code class="language-php">$query = $em->createQueryBuilder()
     ->select('order', 'items')
     ->from(Order::class, 'order')
     ->leftJoin('order.items', 'items')
-    ->setMaxResults(10)  // Wrong!
+    ->setMaxResults(10)  // Wrong: 10 rows, not 10 orders
     ->getQuery();</code></pre>
+    <p>You asked for 10 orders and got fewer, some carrying an incomplete <code>items</code> collection.</p>
 
-    <h4>Solution: Use Paginator</h4>
+    <h4>Symptom 2: root entities never read (worse)</h4>
+    <pre><code class="language-php">$total  = $repository->count([]);   // counts ENTITIES
+$offset = 0;
+
+while ($offset &lt; $total) {
+    $batch = $qb->leftJoin('r.tags', 't')->addSelect('t')
+        ->setFirstResult($offset)     // walks ROWS
+        ->setMaxResults(200)
+        ->getQuery()->getResult();
+
+    $offset += 200;                   // advances by ROWS
+}</code></pre>
+    <p>
+        Say each entity spans 40 rows: the first pass consumes 200 rows but yields only 5 entities.
+        <code>$offset</code> jumps to 200 while the <code>while</code> bound is the entity total, so the
+        loop exits and every remaining entity is skipped. Nothing throws -- the batch just ends early.
+    </p>
+
+    <h4>Fix 1: paginate on identifiers, then fetch-join the batch</h4>
+    <pre><code class="language-php">$ids = $qb->select('r.id')
+    ->setFirstResult($offset)
+    ->setMaxResults($batchSize)
+    ->getQuery()
+    ->getSingleColumnResult();   // no join: LIMIT counts entities
+
+$batch = $qb2->leftJoin('r.tags', 't')->addSelect('t')
+    ->where('r.id IN (:ids)')
+    ->setParameter('ids', $ids)
+    ->getQuery()
+    ->getResult();               // join, no LIMIT</code></pre>
+    <p>Preferred inside a batch loop: the identifier query stays cheap and the offset counts entities.</p>
+
+    <h4>Fix 2: Doctrine Paginator</h4>
     <pre><code class="language-php">use Doctrine\ORM\Tools\Pagination\Paginator;
 
 $paginator = new Paginator($query, $fetchJoinCollection = true);
 $orders = iterator_to_array($paginator);</code></pre>
+    <p>
+        Runs the same two-query strategy for you, plus a <code>COUNT</code> for
+        <code>count($paginator)</code>. Best for page-by-page UI listings; in a large batch loop the
+        extra COUNT per iteration is wasted work, so prefer Fix 1 there.
+    </p>
+
+    <div class="alert alert-info">
+        <strong>Rule of thumb</strong> - LIMIT and <code>addSelect()</code> on a to-many association do
+        not belong in one query. To-<em>one</em> joins (<code>ManyToOne</code>, <code>OneToOne</code>)
+        add no rows and stay safe with LIMIT.
+    </div>
 
     <p>
         <a href="https://www.doctrine-project.org/projects/doctrine-orm/en/current/tutorials/pagination.html" target="_blank" class="doc-link">

--- a/tests/Analyzer/NamingConventionAnalyzerTest.php
+++ b/tests/Analyzer/NamingConventionAnalyzerTest.php
@@ -500,7 +500,6 @@ final class NamingConventionAnalyzerTest extends TestCase
                     break;
 
                 case 'missing_id_suffix':
-                case 'not_snake_case':
                     // Foreign key violations are CRITICAL
                     if (isset($data['fk_column'])) {
                         self::assertEquals('critical', $severity, 'FK violations should be CRITICAL severity');

--- a/tests/Analyzer/SetMaxResultsWithCollectionJoinAnalyzerTest.php
+++ b/tests/Analyzer/SetMaxResultsWithCollectionJoinAnalyzerTest.php
@@ -346,4 +346,119 @@ final class SetMaxResultsWithCollectionJoinAnalyzerTest extends TestCase
         // This is a CRITICAL issue due to silent data loss
         self::assertEquals('critical', $data['severity']);
     }
+
+    #[Test]
+    public function it_reports_the_observed_limit_and_join_count(): void
+    {
+        $queries = QueryDataBuilder::create()
+            ->addQuery('SELECT t0_.id, t1_.id FROM posts t0_ LEFT JOIN comments t1_ ON t0_.id = t1_.post_id LIMIT 25')
+            ->build();
+
+        $issues = $this->analyzer->analyze($queries);
+        $description = $issues->toArray()[0]->getDescription();
+
+        self::assertStringContainsString('Observed: LIMIT 25 applied across 1 fetch-joined table(s).', $description);
+    }
+
+    #[Test]
+    public function it_reports_the_row_count_when_the_profiler_provides_it(): void
+    {
+        $queries = QueryDataBuilder::create()
+            ->addQueryWithRowCount(
+                'SELECT t0_.id, t1_.id FROM posts t0_ LEFT JOIN comments t1_ ON t0_.id = t1_.post_id LIMIT 200',
+                200,
+            )
+            ->build();
+
+        $issues = $this->analyzer->analyze($queries);
+        $description = $issues->toArray()[0]->getDescription();
+
+        self::assertStringContainsString('the database returned 200 row(s) for this LIMIT 200', $description);
+        self::assertStringContainsString('truncated in the middle of a root entity', $description);
+    }
+
+    #[Test]
+    public function it_omits_the_row_count_facts_when_no_row_count_is_available(): void
+    {
+        $queries = QueryDataBuilder::create()
+            ->addQuery('SELECT t0_.id, t1_.id FROM posts t0_ LEFT JOIN comments t1_ ON t0_.id = t1_.post_id LIMIT 200')
+            ->build();
+
+        $issues = $this->analyzer->analyze($queries);
+        $description = $issues->toArray()[0]->getDescription();
+
+        self::assertStringNotContainsString('the database returned', $description);
+        self::assertStringContainsString('Observed: LIMIT 200', $description);
+    }
+
+    #[Test]
+    public function it_does_not_claim_truncation_when_the_row_count_stays_below_the_limit(): void
+    {
+        $queries = QueryDataBuilder::create()
+            ->addQueryWithRowCount(
+                'SELECT t0_.id, t1_.id FROM posts t0_ LEFT JOIN comments t1_ ON t0_.id = t1_.post_id LIMIT 200',
+                87,
+            )
+            ->build();
+
+        $issues = $this->analyzer->analyze($queries);
+        $description = $issues->toArray()[0]->getDescription();
+
+        self::assertStringContainsString('the database returned 87 row(s)', $description);
+        self::assertStringNotContainsString('truncated in the middle of a root entity', $description);
+    }
+
+    #[Test]
+    public function it_warns_about_skipped_root_entities_when_the_query_is_offset_past_the_first_page(): void
+    {
+        $queries = QueryDataBuilder::create()
+            ->addQuery('SELECT t0_.id, t1_.id FROM posts t0_ LEFT JOIN comments t1_ ON t0_.id = t1_.post_id LIMIT 200 OFFSET 200')
+            ->build();
+
+        $issues = $this->analyzer->analyze($queries);
+        $description = $issues->toArray()[0]->getDescription();
+
+        self::assertStringContainsString('non-zero OFFSET', $description);
+        self::assertStringContainsString('never read the remaining root entities', $description);
+    }
+
+    #[Test]
+    public function it_warns_about_skipped_root_entities_with_mysql_comma_limit_syntax(): void
+    {
+        $queries = QueryDataBuilder::create()
+            ->addQuery('SELECT t0_.id, t1_.id FROM posts t0_ LEFT JOIN comments t1_ ON t0_.id = t1_.post_id LIMIT 200, 200')
+            ->build();
+
+        $issues = $this->analyzer->analyze($queries);
+        $description = $issues->toArray()[0]->getDescription();
+
+        self::assertStringContainsString('non-zero OFFSET', $description);
+    }
+
+    #[Test]
+    public function it_does_not_warn_about_skipped_root_entities_on_the_first_page(): void
+    {
+        $queries = QueryDataBuilder::create()
+            ->addQuery('SELECT t0_.id, t1_.id FROM posts t0_ LEFT JOIN comments t1_ ON t0_.id = t1_.post_id LIMIT 200 OFFSET 0')
+            ->build();
+
+        $issues = $this->analyzer->analyze($queries);
+        $description = $issues->toArray()[0]->getDescription();
+
+        self::assertStringNotContainsString('non-zero OFFSET', $description);
+    }
+
+    #[Test]
+    public function it_suggests_both_remediations_in_the_description(): void
+    {
+        $queries = QueryDataBuilder::create()
+            ->addQuery('SELECT t0_.id, t1_.id FROM posts t0_ LEFT JOIN comments t1_ ON t0_.id = t1_.post_id LIMIT 10')
+            ->build();
+
+        $issues = $this->analyzer->analyze($queries);
+        $description = $issues->toArray()[0]->getDescription();
+
+        self::assertStringContainsString('WHERE id IN (:ids)', $description);
+        self::assertStringContainsString('Paginator', $description);
+    }
 }

--- a/tests/Unit/Analyzer/Parser/SqlPerformanceAnalyzerOffsetTest.php
+++ b/tests/Unit/Analyzer/Parser/SqlPerformanceAnalyzerOffsetTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Doctrine Doctor.
+ * (c) 2025-2026 Ahmed EBEN HASSINE
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace AhmedBhs\DoctrineDoctor\Tests\Unit\Analyzer\Parser;
+
+use AhmedBhs\DoctrineDoctor\Analyzer\Parser\SqlPerformanceAnalyzer;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * hasOffset() answers whether a query actually skips rows.
+ *
+ * The SQL parser reports an offset of 0 for a bare LIMIT, so a naive
+ * "is the offset set" check reports an offset for every LIMIT query.
+ * Callers rely on this to tell a first page from a later one.
+ */
+final class SqlPerformanceAnalyzerOffsetTest extends TestCase
+{
+    private SqlPerformanceAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        $this->analyzer = new SqlPerformanceAnalyzer();
+    }
+
+    /**
+     * @return array<string, array{string, bool}>
+     */
+    public static function offsetProvider(): array
+    {
+        return [
+            'bare limit has no offset'              => ['SELECT a FROM t LIMIT 10', false],
+            'explicit zero offset is not an offset' => ['SELECT a FROM t LIMIT 10 OFFSET 0', false],
+            'non zero offset'                       => ['SELECT a FROM t LIMIT 10 OFFSET 20', true],
+            'mysql comma syntax with offset'        => ['SELECT a FROM t LIMIT 20, 10', true],
+            'mysql comma syntax first page'         => ['SELECT a FROM t LIMIT 0, 10', false],
+            'standalone offset'                     => ['SELECT a FROM t OFFSET 5', true],
+            'standalone zero offset'                => ['SELECT a FROM t OFFSET 0', false],
+            'no pagination at all'                  => ['SELECT a FROM t', false],
+            'non select statement'                  => ['UPDATE t SET a = 1', false],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('offsetProvider')]
+    public function it_detects_only_offsets_that_skip_rows(string $sql, bool $expected): void
+    {
+        self::assertSame($expected, $this->analyzer->hasOffset($sql));
+    }
+}


### PR DESCRIPTION
## What

Two changes to the `setMaxResults() with Collection Join` detection path.

**The alert message now reports what it measured.** It stated the anti-pattern in the abstract and read identically for every query. It now includes the LIMIT value and the number of fetch-joined tables, the row count when the profiler reports one, and a note when a result set reached its LIMIT and was therefore very likely truncated mid entity. When the query is offset past the first page it also warns about the severe failure mode the old message never mentioned: a batch loop bounded by a root entity count exits early and never reads the remaining entities, losing whole entities rather than just collection items. Both remediations are given — paginating on identifiers, and `Paginator` — with the trade-off between them.

Every enrichment degrades to the base message when the profiler reports no row count, so the alert stays complete either way. **Detection logic is untouched**, so the false-positive suite is unaffected.

**`hasOffset()` returned true for every `LIMIT` query.** The SQL parser exposes an offset of `0` for a bare `LIMIT`, and the guard tested it with `'' !== (string) $offset`, which holds for `"0"`. The standalone-`OFFSET` regex fallback matched `OFFSET 0` for the same reason. It now compares against `0`.

This leaked into a second analyzer: `PaginationWithoutOrderByAnalyzer` derives its severity from this call, so a plain `LIMIT` without `ORDER BY` was reported as `LIMIT/OFFSET pagination` at `warning` instead of `LIMIT` at `info`.

| Query | Before | After |
|---|---|---|
| `LIMIT 10` | `warning` — LIMIT/OFFSET pagination | `info` — LIMIT |
| `LIMIT 10 OFFSET 20` | `warning` — LIMIT/OFFSET pagination | unchanged |

`OrderByWithoutLimitAnalyzer` is unaffected: it reads `hasLimit() || hasOffset()`, and the first call already covered these queries.

## Tests

`hasOffset()` had no coverage. Added a case per pagination form, including MySQL comma syntax (`LIMIT 20, 10`) and explicit zero offsets. Added 8 cases for the enriched message covering both the present and absent row count paths, offset and first-page, and the truncation threshold.

- Full suite: 2738 tests, 0 failures
- PHPStan level 8, ECS, PHPMD, Deptrac: clean
- Rector: clean on the changed files

## Note

`composer check` is red on `main` before this branch — Rector wants to rewrite 105 files it flags repo-wide (`ClosureToArrowFunctionRector`, `NullToStrictStringFuncCallArgRector`). Pre-existing and unrelated; not addressed here.
