### PR TITLE
chore(deps): constrain doctrine/orm to ^3.0 in require-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `doctrine/orm` in `require-dev` is constrained to `^3.0` instead of `^3.0|^4.0`. No 4.x has been released — Packagist lists only the `4.0.x-dev` branch — so the upper bound allowed the development branch of an unreleased major to be resolved, whose BC breaks are by definition unknown and untested here. ORM 3.6 already deprecates mappings that 4.0 will reject, which is exactly the window in which an accidental resolution would fail in confusing ways. The constraint was widened in ec60e80 as part of a broad modernization commit rather than as a deliberate targeting of ORM 4, and nothing in the CI matrix, the documentation or the code refers to it. Runtime dependencies are unaffected: the bundle requires `doctrine/doctrine-bundle` rather than the ORM directly, so this changes only what the bundle's own test suite resolves against.
+
 ## [2.10.2] - 2026-08-24
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
   },
   "require-dev": {
     "deptrac/deptrac": "^4.2",
-    "doctrine/orm": "^3.0|^4.0",
+    "doctrine/orm": "^3.0",
     "pdepend/pdepend": "3.x-dev",
     "php-parallel-lint/php-parallel-lint": "^1.4",
     "phpmd/phpmd": "3.x-dev",


### PR DESCRIPTION
## The problem

`require-dev` declared `doctrine/orm: "^3.0|^4.0"`, but **no 4.x has been released**. Packagist lists only the `4.0.x-dev` branch:

```
$ composer show doctrine/orm --all | grep -E "4\.[0-9]"
versions : 4.0.x-dev
```

So the upper bound allowed the development branch of an unreleased major to be resolved, with BC breaks that are by definition unknown and untested here. ORM 3.6 already deprecates mappings that 4.0 will reject — `nullable` on primary keys, string defaults on temporal columns, `WITH` in arbitrary joins — which is exactly the window where an accidental resolution fails in confusing ways.

The bound came in via ec60e80, a broad modernization commit, not a deliberate targeting of ORM 4. Nothing in the CI matrix, the documentation or the code refers to ORM 4.

## Scope

`require-dev` only. The bundle requires `doctrine/doctrine-bundle`, not the ORM directly, so **runtime dependencies for users are unchanged** — this only affects what the bundle's own test suite resolves against.

## Verification

Verified against the current stable releases, updated locally as part of this work:

| Package | Was | Now |
|---|---|---|
| `doctrine/orm` | 3.6.2 | 3.6.8 |
| `doctrine/dbal` | 4.4.2 | 4.4.4 |

Against those versions: 2865 tests pass, PHPStan level 8 clean, ECS clean. No deprecation or signature change in ORM 3.6.3→3.6.8 or DBAL 4.4.3→4.4.4 affects this codebase.

`composer.lock` is gitignored, so those version bumps are local only and CI re-resolves them on every run — the constraint change in `composer.json` is the entire committed diff.

## Note, unrelated to this change

`composer audit` reports 5 advisories on 4 production packages, all Symfony, none Doctrine. The local resolution pulls `symfony/routing` v8.0.6 while the fixes land in 8.0.13 (CVE-2026-48784, CVE-2026-45065). Since the lock is not tracked, this reflects local resolution rather than anything shipped. Worth a separate look, out of scope here.